### PR TITLE
D_D_to_He3_reactions function

### DIFF
--- a/src/physics/sources.jl
+++ b/src/physics/sources.jl
@@ -180,7 +180,7 @@ end
 Calculates the number of D-D thermal fusion reactions to He3 in [reactions/m³/s]
 """
 function D_D_to_He3_reactions(dd::IMAS.dd)
-    index = findfirst(ion.label == "D" for ion in dd.core_profiles.profiles_1d[1].ion)
+    index = findfirst(ion.label == "D" for ion in dd.core_profiles.profiles_1d[].ion)
     @assert index !== nothing "There is no Deuterium only species in dd.core_profiles"
     dd_deut = dd.core_profiles.profiles_1d[].ion[index]
     return dd_deut.density_thermal.^2 .* reactivity(dd_deut.temperature, "D-DtoHe3") #  reactions/m³/s


### PR DESCRIPTION
Made a `D_D_to_He3_reactions` function, simply use by calling it:

```julia
IMAS.D_D_to_He3_reactions(dd)
```
For a dd that has Deuterium in it (you can use the standard D3D case via)
```julia
dd, ini, act = FUSE.init(:D3D)
```