### PR TITLE
use `float` not `convert` (make IMAS precompile on 1.9)

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -15,16 +15,16 @@ Named tuple with physics constants:
     m_u = 1.6605390666e-27
 """
 const constants = (
-    μ_0=convert(Float64, PCs.μ_0).val,
-    c=convert(Float64, PCs.c_0).val,
-    ϵ_0=convert(Float64, PCs.ε_0).val,
-    k_B=convert(Float64, PCs.k_B).val,
-    e=convert(Float64, PCs.e).val,
-    m_e=convert(Float64, PCs.m_e).val,
-    m_p=convert(Float64, PCs.m_p).val,
-    m_n=convert(Float64, PCs.m_n).val,
-    atm=convert(Float64, PCs.atm).val,
-    m_u=convert(Float64, PCs.m_u).val
+    μ_0=float(Float64, PCs.μ_0).val,
+    c=float(Float64, PCs.c_0).val,
+    ϵ_0=float(Float64, PCs.ε_0).val,
+    k_B=float(Float64, PCs.k_B).val,
+    e=float(Float64, PCs.e).val,
+    m_e=float(Float64, PCs.m_e).val,
+    m_p=float(Float64, PCs.m_p).val,
+    m_n=float(Float64, PCs.m_n).val,
+    atm=float(Float64, PCs.atm).val,
+    m_u=float(Float64, PCs.m_u).val
 )
 
 const index_2_name__core_transport__model = Dict(


### PR DESCRIPTION
this usage is more in line with the documentation anyways

https://juliaphysics.github.io/PhysicalConstants.jl/stable/usage/
