### PR TITLE
Fixes to find x points

### DIFF
--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -761,16 +761,21 @@ function find_x_point!(eqt::IMAS.equilibrium__time_slice)::IDSvector{<:IMAS.equi
         for k in reverse!(sort(i_x))
             deleteat!(eqt.boundary.x_point, k)
             deleteat!(psidist_lcfs_xpoints, k)
+            deleteat!(z_x,k)
         end
 
         # remove x-points that have fallen on the magnetic axis
         index = psidist_lcfs_xpoints .> -5E-3 # positive means outside of the lcfs
         psidist_lcfs_xpoints = psidist_lcfs_xpoints[index]
         eqt.boundary.x_point = eqt.boundary.x_point[index]
+        z_x = z_x[index]
 
         # sort a second time now by distance in psi
         index = sortperm(abs.(psidist_lcfs_xpoints))
         eqt.boundary.x_point = eqt.boundary.x_point[index]
+        z_x = z_x[index]
+        # save up to the x_point with Z coordinate opposite to first x point; note z_x.*z_x[1] is < 0 only in one x_point
+        eqt.boundary.x_point = eqt.boundary.x_point[1:argmin(z_x.*z_x[1])]
     end
 
     return eqt.boundary.x_point


### PR DESCRIPTION
Small fixes to find x_point

Two changes:

- The threshold to eliminate the null found inside the separatrix was too low (in same cases the x point on the lcfs was discarded because inside the threshold). Threshold has been increased from -1e-3 to -5e-3.

- There was a bug on how many x-points were saved. X points are first saved, sorted in distance to the lcfs (closest to furthest). The code stops when it finds the first null with opposite Z to the x point in the lcfs. Subsequently the x points are sorted in psi. It can occur that there are x points which are closer geometrically to the lcfs but their distance in psi is greater than the last x point that we want to save (the null with opposite z). Therefore more x-points than the ones that we wanted were stored. See example:
<img width="593" alt="image" src="https://github.com/ProjectTorreyPines/IMAS.jl/assets/142927307/7fa55d25-a91b-4c39-a4a4-51a7b78bc2a9">

Now, before being saved, the code checks and saves only the x-points we want. 
Fixed:
<img width="589" alt="image" src="https://github.com/ProjectTorreyPines/IMAS.jl/assets/142927307/ca9f751f-fbbb-48bc-9f00-344d9e5ee1b3">
 
