### PR TITLE
Fix threshold in find_x_point because new double nulls are too good

### DIFF
--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -992,7 +992,8 @@ function find_x_point!(eqt::IMAS.equilibrium__time_slice)::IDSvector{<:IMAS.equi
 
 
         # remove x-points that have fallen on the magnetic axis 
-        index = psidist_lcfs_xpoints .>= psidist_lcfs_xpoints[argmin(abs.(psidist_lcfs_xpoints))] # positive means outside of the lcfs, psi increase montonically 
+        sign_closest = psidist_lcfs_xpoints[argmin(abs.(psidist_lcfs_xpoints))] # sign of psi of closest X-point in psi to LCFS
+        index = psidist_lcfs_xpoints .>= (1-sign_closest*0.00001)*psidist_lcfs_xpoints[argmin(abs.(psidist_lcfs_xpoints))] # positive means outside of the lcfs, psi increase montonically 
         psidist_lcfs_xpoints = psidist_lcfs_xpoints[index]
         eqt.boundary.x_point = eqt.boundary.x_point[index]
         z_x = z_x[index]


### PR DESCRIPTION
New equilibrium solver is too good with double nulls. The psi distance of the two X-point from the separatrix are equal, up to 1e-10 %..

When the psi of the nulls is too close to each other, one x-point could be potentially removed, mistakenly thought to be inside the lcfs. 

The threshold is then moved by an epsilon to save both.