### PR TITLE
Fix total_radiation_sources: exclude exchange term

### DIFF
--- a/src/physics/sources.jl
+++ b/src/physics/sources.jl
@@ -244,6 +244,10 @@ function total_radiation_sources(
     exclude_indexes::Vector{Int}=Int[]
 ) where {T<:Real}
 
+    # we need to exclude the collisional_equipartition term
+    index = IMAS.name_2_index(core_sources.source)[:collisional_equipartition]
+    push!(exclude_indexes, index)
+
     fields = [:power_inside, :energy]
     only_positive_negative = -1
     return total_sources(core_sources, cp1d; include_indexes, exclude_indexes, fields, only_positive_negative)


### PR DESCRIPTION
In the computation of the radiation sources, one must ignore the collisional term between ions and electrons.

Example ITER + Flux Matcher has the following sources:
<img width="598" alt="image" src="https://github.com/ProjectTorreyPines/IMAS.jl/assets/142927307/27aec9e3-1f77-416a-acaf-7710fb49a84a">

The radiation power should be: bred 23.6 MW + line 12.2 MW + sync 3.88 MW ~ 39.68 MW
With the old function one obtains 87.6 MW:
<img width="597" alt="image" src="https://github.com/ProjectTorreyPines/IMAS.jl/assets/142927307/9162a128-2443-4257-aea6-ae9928a165de">

Which is wrong, the function in this pull request returns the right value:
<img width="597" alt="image" src="https://github.com/ProjectTorreyPines/IMAS.jl/assets/142927307/629fa3ce-d409-4e4b-8a89-875ec99335f0">




