### PR TITLE
compat entries for PTP packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,9 +34,12 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Contour = "0.6"
-DataInterpolations = "=5.2"
+CoordinateConventions = "1"
+DataInterpolations = "5 - 5.2"
 ExpiringCaches = "1"
+FXP = "1"
 FuseUtils = "1"
+IMASDD = "1"
 Interpolations = "0.14.7, 0.15"
 Jedis = "0.3"
 LaTeXStrings = "1"


### PR DESCRIPTION
All PTP packages used by IMAS are properly versioned, so we can start requiring this in IMAS