### PR TITLE
Make centroid work if first and last point differ

### DIFF
--- a/src/math.jl
+++ b/src/math.jl
@@ -42,9 +42,16 @@ end
 Calculate centroid of polygon
 """
 function centroid(x::AbstractVector{<:T}, y::AbstractVector{<:T}) where {T<:Real}
-    A = sum((y[i+1] - y[i]) * 0.5 * (x[i+1] + x[i]) for i in 1:length(x)-1)
-    x_c = -sum((x[i+1] - x[i]) * 0.5 * (y[i+1] + y[i]) * 0.5 * (x[i+1] + x[i]) for i in 1:length(x)-1) / A
-    y_c = sum((y[i+1] - y[i]) * 0.5 * (x[i+1] + x[i]) * 0.5 * (y[i+1] + y[i]) for i in 1:length(x)-1) / A
+    add_endpoint = !((x[1] ≈ x[end]) && (y[1] ≈ y[end]))
+    A = 0.5 * sum(x[i] * y[i+1] - x[i+1] * y[i] for i in 1:length(x)-1)
+    add_endpoint && (A += 0.5 * (x[end] * y[1] - x[1] * y[end]))
+
+    x_c = -sum(0.25 * (x[i+1] - x[i]) * (y[i+1] + y[i]) * (x[i+1] + x[i]) for i in 1:length(x)-1) / A
+    add_endpoint && (x_c -= 0.25 * (x[1] - x[end]) * (y[1] + y[end]) * (x[1] + x[end]) / A )
+
+    y_c = sum(0.25 * (y[i+1] - y[i]) * (x[i+1] + x[i]) * (y[i+1] + y[i]) for i in 1:length(x)-1) / A
+    add_endpoint && (y_c += 0.25 * (y[1] - y[end]) * (x[1] + x[end]) * (y[1] + y[end]) / A)
+
     return x_c, y_c
 end
 
@@ -560,7 +567,7 @@ function min_mean_distance_two_shapes(
     Z_obj1::AbstractVector{<:T},
     R_obj2::AbstractVector{<:T},
     Z_obj2::AbstractVector{<:T}) where {T<:Real}
-    
+
     mean_distance = 0.0
     min_distance = Inf
     for k1 in eachindex(R_obj1)


### PR DESCRIPTION
This was a significant bug in the flux of PF active coils with a point representation, putting the point at a very wrong location since `outline()` did not repeat the first point at the end.
https://github.com/ProjectTorreyPines/FUSE.jl/blob/204077fe5ae932971eaba0fdc21e8d343d4f0881/src/actors/pf/pf_active_utils.jl#L129-L132

This got used a few other places too, but wouldn't have caused an issue if the first and last point were the same.