### PR TITLE
Fix mesher hf

### DIFF
--- a/src/physics/particles.jl
+++ b/src/physics/particles.jl
@@ -159,6 +159,7 @@ function find_flux(particles::Vector{particle{T}}, I_per_trace::T, rwall::Vector
     wall_s = d .* wall_r .* 2π
 
     if debug
+        @show minimum(d)
         @show length(d)
         @show length(l)
         @show ns
@@ -187,7 +188,7 @@ function find_flux(particles::Vector{particle{T}}, I_per_trace::T, rwall::Vector
 
         σw = maximum([1250 * l[end] / length(particles), 2 * maximum([dr, dz])])  # standard deviation of the distribution
     end
-
+    @assert minimum(d) !== 0.0 "Error in mesher_HF: mesh has repeating points, instead of unique ones"
     ns = maximum([ns, Int(ceil(5 * σw / minimum(d)))])
 
     # check that the window size is smaller than the whole wall

--- a/src/physics/thermal_loads.jl
+++ b/src/physics/thermal_loads.jl
@@ -698,6 +698,14 @@ function mesher_HF(dd::IMAS.dd;
                 add_z = zwall[rwall.>(minimum([Rwall[ind],Rwall[ind+1]])-dr) .&& rwall .< (maximum([Rwall[ind],Rwall[ind+1]])+dr ).&&
                               zwall.>(minimum([Zwall[ind],Zwall[ind+1]])-dz) .&& zwall .< (maximum([Zwall[ind],Zwall[ind+1]])+dz)   ]
                 #! format: on
+                
+                # check that (add_r,add_z) are unique points
+                add_rz = unique!(collect(zip(add_r,add_z)))
+                if length(add_r) > length(add_rz)
+                    add_r  = [rz[1] for rz in add_rz]
+                    add_z  = [rz[2] for rz in add_rz]
+                end
+
                 Rwall = append!(Rwall[1:ind], add_r, Rwall[ind+1:end])
                 Zwall = append!(Zwall[1:ind], add_z, Zwall[ind+1:end])
             end


### PR DESCRIPTION
In a super rare coincidence, the mesher would return a mesh with repeating points. Those points would have zero distance between each other. In a later stage, this distance is used to normalize the standard deviation of the gaussians (= particles) that are thrown to the wall. This would have led to infinity.
Now:
- check that one does not add twice the same point in the mesh
- throw error, pointing to the mesher, if for whatever reason this happens a second time