### PR TITLE
Enhance the compatibility of @recipes in plot.jl for other backends (e.g. plotlyjs(), unicodeplots())

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -593,7 +593,7 @@ end
                 subplot := 2
                 normalization := 1E-6
                 ylabel := ""
-                title := L"P~~[MPa]"
+                title := latex_support() ? L"P~~[MPa]" : "P [MPa]"
                 eqt.profiles_1d, :pressure
             end
         end
@@ -608,7 +608,7 @@ end
                     subplot := 2
                     normalization := 1E-6
                     ylabel := ""
-                    title := L"P~~[MPa]"
+                    title := latex_support() ? L"P~~[MPa]" : "P [MPa]"
                     cp1d, :pressure
                 end
             end
@@ -622,7 +622,7 @@ end
                 subplot := 3
                 normalization := 1E-6
                 ylabel := ""
-                title := L"J_{tor}~[MA/m^2]"
+                title := latex_support() ? L"J_{tor}~[MA/m^2]" : "Jtor [MA/m^2]"
                 eqt.profiles_1d, :j_tor
             end
         end
@@ -637,7 +637,7 @@ end
                     subplot := 3
                     normalization := 1E-6
                     ylabel := ""
-                    title := L"J_{tor}~[MA/m^2]"
+                    title := latex_support() ? L"J_{tor}~[MA/m^2]" : "Jtor [MA/m^2]"
                     cp1d, :j_tor
                 end
             end
@@ -651,10 +651,10 @@ end
                 ylabel := ""
                 normalization := 1.0
                 if contains(string(coordinate), "psi")
-                    title := L"\rho"
+                    title := latex_support() ? L"\rho" : "ρ"
                     eqt.profiles_1d, :rho_tor_norm
                 else
-                    title := L"\psi~~[Wb]"
+                    title := latex_support() ? L"\psi~~[Wb]" : "ψ [Wb]"
                     eqt.profiles_1d, :psi
                 end
             end
@@ -676,7 +676,7 @@ end
                 subplot := 5
                 ylabel := ""
                 normalization := 1.0
-                title := L"q"
+                title := latex_support() ? L"q" : "q"
                 eqt.profiles_1d, :q
             end
         end
@@ -2832,13 +2832,17 @@ end
     end
 end
 
+function latex_support()
+    return Plots.backend_name() in [:gr, :pgfplotsx, :pythonplot, :inspectdr]
+end
+
 #= ================== =#
 #  handling of labels  #
 #= ================== =#
 nice_field_symbols = Dict()
-nice_field_symbols["rho_tor_norm"] = L"\rho"
-nice_field_symbols["psi"] = L"\psi"
-nice_field_symbols["psi_norm"] = L"\psi_N"
+nice_field_symbols["rho_tor_norm"] = () -> latex_support() ? L"\rho" : "ρ"
+nice_field_symbols["psi"] = () -> latex_support() ? L"\psi" : "ψ"
+nice_field_symbols["psi_norm"] = () -> latex_support() ? L"\psi_N" : "ψₙ"
 nice_field_symbols["rotation_frequency_tor_sonic"] = "Rotation"
 nice_field_symbols["i_plasma"] = "Plasma current"
 nice_field_symbols["b_field_tor_vacuum_r"] = "B₀×R₀"
@@ -2849,6 +2853,7 @@ nice_field_symbols["geometric_axis.z"] = "Zgeo"
 function nice_field(field::AbstractString)
     if field in keys(nice_field_symbols)
         field = nice_field_symbols[field]
+        return field isa Function ? field() : field
     else
         field = replace(field,
             r"n_e" => "nₑ",
@@ -2883,7 +2888,7 @@ function nice_units(units::String)
     if length(units) > 0
         units = replace(units, r"\^([-+]?[0-9]+)" => s"^{\1}")
         units = replace(units, "." => s"\\,")
-        units = L"[%$units]"
+        units = latex_support() ? L"[%$units]" : "[$units]"
         units = " " * units
     end
     return units

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -2918,3 +2918,8 @@ function hash_to_color(input::Any; seed::Int=0)
     # Return an RGB color using Plots' RGB type
     return RGB(r, g, b)
 end
+
+# To fix a vscode's bug w.r.t UnicodePlots
+# (see https://github.com/JuliaPlots/Plots.jl/issues/4956  for more details)
+Base.showable(::MIME"image/png", ::Plots.Plot{Plots.UnicodePlotsBackend}) = applicable(UnicodePlots.save_image, devnull)
+

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -593,7 +593,7 @@ end
                 subplot := 2
                 normalization := 1E-6
                 ylabel := ""
-                title := latex_support() ? L"P~~[MPa]" : "P [MPa]"
+                title := latex_support() ? L"P~~\mathrm{[MPa]}" : "P [MPa]"
                 eqt.profiles_1d, :pressure
             end
         end
@@ -608,7 +608,7 @@ end
                     subplot := 2
                     normalization := 1E-6
                     ylabel := ""
-                    title := latex_support() ? L"P~~[MPa]" : "P [MPa]"
+                    title := latex_support() ? L"P~~\mathrm{[MPa]}" : "P [MPa]"
                     cp1d, :pressure
                 end
             end
@@ -622,7 +622,7 @@ end
                 subplot := 3
                 normalization := 1E-6
                 ylabel := ""
-                title := latex_support() ? L"J_{tor}~[MA/m^2]" : "Jtor [MA/m^2]"
+                title := latex_support() ? L"J_\mathrm{tor}~[\mathrm{MA/m^2}]" : "Jtor [MA/m²]"
                 eqt.profiles_1d, :j_tor
             end
         end
@@ -637,7 +637,7 @@ end
                     subplot := 3
                     normalization := 1E-6
                     ylabel := ""
-                    title := latex_support() ? L"J_{tor}~[MA/m^2]" : "Jtor [MA/m^2]"
+                    title := latex_support() ? L"J_\mathrm{tor}~[\mathrm{MA/m^2}]" : "Jtor [MA/m²]"
                     cp1d, :j_tor
                 end
             end
@@ -654,7 +654,7 @@ end
                     title := latex_support() ? L"\rho" : "ρ"
                     eqt.profiles_1d, :rho_tor_norm
                 else
-                    title := latex_support() ? L"\psi~~[Wb]" : "ψ [Wb]"
+                    title := latex_support() ? L"\psi~~[\mathrm{Wb}]" : "Ψ [Wb]"
                     eqt.profiles_1d, :psi
                 end
             end
@@ -2842,7 +2842,7 @@ end
 nice_field_symbols = Dict()
 nice_field_symbols["rho_tor_norm"] = () -> latex_support() ? L"\rho" : "ρ"
 nice_field_symbols["psi"] = () -> latex_support() ? L"\psi" : "ψ"
-nice_field_symbols["psi_norm"] = () -> latex_support() ? L"\psi_N" : "ψₙ"
+nice_field_symbols["psi_norm"] = () -> latex_support() ? L"\psi_\mathrm{N}" : "ψₙ"
 nice_field_symbols["rotation_frequency_tor_sonic"] = "Rotation"
 nice_field_symbols["i_plasma"] = "Plasma current"
 nice_field_symbols["b_field_tor_vacuum_r"] = "B₀×R₀"
@@ -2888,7 +2888,7 @@ function nice_units(units::String)
     if length(units) > 0
         units = replace(units, r"\^([-+]?[0-9]+)" => s"^{\1}")
         units = replace(units, "." => s"\\,")
-        units = latex_support() ? L"[%$units]" : "[$units]"
+        units = latex_support() ? L"[\mathrm{%$units}]" : "[$units]"
         units = " " * units
     end
     return units

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -567,6 +567,9 @@ end
 
     if !cx
         layout := RecipesBase.@layout [a{0.35w} [a b; c d]]
+        if Plots.backend_name() == :unicodeplots
+            layout := 5
+        end
         size --> (800, 500)
     end
 


### PR DESCRIPTION
# Summary
This PR updates some `@recipes` in `plot.jl` to allow it more compatible with other `Plots`' backends (e.g., `plotlyjs()`, `unicodeplots()`), with respect to latex rendering and complex layout.

##  Issues that this PR resolved
### 1. Some backends do not support latex rendering
As some backends, out of the box, do not support latex rendering, labels using `LaTexStrings` can result in ugly labels or even errors.
This PR resolves the issue by checking whether the current backend supports the latex rendering (by a new function `latex_support()`), and determining whether to use `LaTeXStrings` or alternative plain/Unicode text.
(Note that the alternative text must be defined upfront.)

### 2. `unicodeplots` backend cannot support complex `@layout` macro
For example, `unicodeplots` backend cannot handle `@layout [a{0.35w} [a b; c d]]`.
This PR resolved this issue by simplifying the `@layout` in some recipes when the current backend is `unicodeplots`.

In addition, vscode has a weird bug when using `UnicodePlots`, which is fixed by some workaround (see the last commit about `Base.showable`). 

### 3. small styling changes
In addition, there are small styling changes to use Romanized text for units and descriptive subscripts in labels.

# Exisiting Feature
### 1. `gr()` backend:
The current `@recipes` focus on the `gr()` backend, which natively supports the latex rendering.
The units and subscripts in the labels are in italics.
```julia
gr()
plot(dd.equilibrium) # Okay, with italic units
```
![Before_gr](https://github.com/user-attachments/assets/ed75a47b-bc4f-42da-b859-1dc50ae2a1d0)

### 2. `plotlyjs()` backend:
`plotlyjs()` backend also works, but results in ugly labels (e.g., `$psi_N$`)
``` julia
plotlyjs()
plot(dd.equilibrium) # Okay, but with ugly labels
```
![Before_plotlyjs](https://github.com/user-attachments/assets/c6de3cb6-1e12-471d-b11c-fdc2fb6c71ed)


### 3. `unicodeplots()` backend:
`unicodeplots()` backend does not work with many recipes due to the `LaTexSTrings` and custom layouts.
``` julia
unicodeplots()
plot(dd.equilibrium) # Error!! due to latex label
```
![Screenshot 2024-11-06 at 11 51 22 AM](https://github.com/user-attachments/assets/fedfe9d3-8ecc-4a2d-9664-2496f2a95e4a)
``` julia
unicodeplots()
#Even if we fixed the latex label issue,
#This still produces error due to complex `@layout` macro
plot(dd.equilibrium) # Error!! due to complex @layout macro
```
![Screenshot 2024-11-06 at 9 55 07 AM](https://github.com/user-attachments/assets/ccdee2ca-27fa-4382-9dc0-84ac891bff81)


# New Feature

### 1. `gr()` backend:
```julia
gr()
plot(dd.equilibrium) # Okay, with roman-type units
```

![After_gr](https://github.com/user-attachments/assets/325cfcc6-62b0-40c6-93e6-1cbde534c35b)

### 2. `plotlyjs()` backend:
`plotlyjs()` backend now works with predefined plain/unicode labels.

However, the `aspect_ratio=:equal` does not work correctly such that `x`-axis is slightly exaggerated.
``` julia
plotlyjs()
plot(dd.equilibrium) # Okay, incorrect aspect_ratio
```

![After_plotlyjs](https://github.com/user-attachments/assets/cc0bdb7f-b0a1-4883-ad83-da867ad8bc08)


### 3. `unicodeplots()` backend:
`unicodeplots()` backend now works with some limitations and simplified layouts.
``` julia
unicodeplots()
# works with simplified layout, and unicode labels
plot(dd.equilibrium; psi_levels_in=5) 
```
![Screenshot 2024-11-06 at 11 34 00 AM](https://github.com/user-attachments/assets/b7092eae-3eab-4a83-822c-f535d845670b)

``` julia
unicodeplots()
plot(dd.core_profiles)
```
![Screenshot 2024-11-06 at 10 33 52 AM](https://github.com/user-attachments/assets/110e2e89-e690-414b-af7b-79d286714f88)



## Limitations
`Plots.jl` is great, but may not be fully compatible with various backends (e.g., `plotlyjs()`, `unicodeplots()`).

Some compatibility issues can be resolved with backend-specific recipes, but it can be difficult to utilize the full functionality.

For example, if we plan to provide more advanced, fully-featured interactive plots for users, we may consider using `Plotly.jl` or `PlotlyJS.jl` directly, not through `Plots.jl`.

