### PR TITLE
Fix a bug in "plot_field" recipe

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -2767,6 +2767,12 @@ end
     coordinate_name = coords.names[1]
     coordinate_value = coords.values[1]
 
+    # If the field is the reference coordinate of the given IDS,
+    # set the coordinate_value as its index
+    if coordinate_name == "1...N"
+        coordinate_value = 1:length(getproperty(ids, field))
+    end
+
     xvalue = coordinate_value
     yvalue = getproperty(ids, field) .* normalization
 
@@ -2788,7 +2794,11 @@ end
             label = nice_field(field)
         end
 
-        xlabel --> nice_field(i2p(coordinate_name)[end]) * nice_units(units(coordinate_name))
+        if coordinate_name == "1...N"
+            xlabel --> "index"
+        else
+            xlabel --> nice_field(i2p(coordinate_name)[end]) * nice_units(units(coordinate_name))
+        end
         ylabel --> ylabel
         label --> label
 


### PR DESCRIPTION
## Summary
This PR fixes a bug in the "plot_field" recipe when a given field is the reference coordinate.

## Bug description
```julia
# The following commands encounter the following errors
plot(dd.core_profiles.profiles_1d[1].grid, :rho_tor_norm) # Error!
plot(dd.equilibrium.time_slice[].profiles_1d, :psi) # Error!
```

<img src="https://github.com/user-attachments/assets/5db7e9d2-4370-421a-911b-cb7b3bbbeaec" width="400">

## After fix
```julia
# The following commands plot graphs where the x-axis indicates the "index"
plot(dd.core_profiles.profiles_1d[1].grid, :rho_tor_norm) # Okay
plot(dd.equilibrium.time_slice[].profiles_1d, :psi) # Okay
```
<img src="https://github.com/user-attachments/assets/e825cedb-ae2d-4d40-862a-a5314edc05a4" width="400">

<img src="https://github.com/user-attachments/assets/38d0741d-9cf0-45f5-97c9-d637a076c045" width="400">


