### PR TITLE
feature/plot_recipes_for_IFF

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -2941,7 +2941,4 @@ function hash_to_color(input::Any; seed::Int=0)
     return RGB(r, g, b)
 end
 
-# To fix a vscode's bug w.r.t UnicodePlots
-# (see https://github.com/JuliaPlots/Plots.jl/issues/4956  for more details)
-Base.showable(::MIME"image/png", ::Plots.Plot{Plots.UnicodePlotsBackend}) = applicable(UnicodePlots.save_image, devnull)
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -2224,7 +2224,7 @@ end
             end
         end
         dd = top_dd(smcs)
-        if dd!== nothing
+        if dd !== nothing
             r_nose = smcs.grid.r_tf[1] + (smcs.grid.r_tf[end] - smcs.grid.r_tf[1]) * dd.build.tf.nose_hfs_fraction
             @series begin
                 seriestype := :vline
@@ -2772,12 +2772,12 @@ end
 @recipe function plot_IFF_list(IFF_list::AbstractArray{IDS_Field_Finder}; nrows=:auto, ncols=:auto, each_size=(500, 400))
 
     id = plot_help_id(IFF_list)
-    assert_type_and_record_argument(id, Tuple{Integer, Integer}, "Size of each subplot. (Default=(500, 400))"; each_size)
-    assert_type_and_record_argument(id, Union{Integer, Symbol}, "Number of rows for subplots' layout (Default = :auto)"; nrows)
-    assert_type_and_record_argument(id, Union{Integer, Symbol}, "Number of columns for subplots' layout (Default = :auto)"; ncols)
+    assert_type_and_record_argument(id, Tuple{Integer,Integer}, "Size of each subplot. (Default=(500, 400))"; each_size)
+    assert_type_and_record_argument(id, Union{Integer,Symbol}, "Number of rows for subplots' layout (Default = :auto)"; nrows)
+    assert_type_and_record_argument(id, Union{Integer,Symbol}, "Number of columns for subplots' layout (Default = :auto)"; ncols)
 
     # Keep only non-empty Vector or Matrix type data
-    IFF_list = filter(IFF -> IFF.field_type <: Union{AbstractVector{<:Real}, AbstractMatrix{<:Real}}, IFF_list)
+    IFF_list = filter(IFF -> IFF.field_type <: Union{AbstractVector{<:Real},AbstractMatrix{<:Real}}, IFF_list)
     IFF_list = filter(IFF -> length(IFF.value) > 0, IFF_list)
 
     # At least one valid filed name is required to proceed
@@ -2852,7 +2852,7 @@ function shorten_ids_name(full_name::String, abbreviations::Dict=default_abbrevi
 end
 
 @recipe function plot_IFF(IFF::IDS_Field_Finder; abbreviations=default_abbreviations, seriestype_2d=:line, seriestype_3d=:contourf, nicer_title=true)
-    if Plots.backend_name() == :unicodeplots && seriestype_3d==:contourf
+    if Plots.backend_name() == :unicodeplots && seriestype_3d == :contourf
         # unicodeplots cannot render :contourf, use :contour instead
         seriestype_3d = :contour
     end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -2759,8 +2759,6 @@ end
 #  generic plotting  #
 #= ================ =#
 
-using Plots.PlotMeasures
-
 @recipe function plot_multiple_fields(ids::Union{IDS,IDSvector}, target_fields::Union{AbstractArray{Symbol},Regex})
 
     @series begin
@@ -2820,8 +2818,8 @@ end
     size := (ncols * each_size[1], nrows * each_size[2])
 
     legend_position --> :best
-    left_margin --> [10mm 10mm]
-    bottom_margin --> 10mm
+    left_margin --> [10 * Measures.mm 10 * Measures.mm]
+    bottom_margin --> 10 * Measures.mm
 
     # Create subplots for the current group
     for IFF in IFF_list

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -2833,7 +2833,7 @@ end
     end
 end
 
-default_abbreviations = Dict(
+const default_abbreviations = Dict(
     "dd." => "",
     "equilibrium" => "eq",
     "description" => "desc",
@@ -2844,7 +2844,7 @@ default_abbreviations = Dict(
 )
 
 # Function to shorten names directly in the original text
-function shorten_ids_name(full_name::String; abbreviations::Dict=default_abbreviations)
+function shorten_ids_name(full_name::String, abbreviations::Dict=default_abbreviations)
     # Apply each abbreviation to the full name
     for (key, value) in abbreviations
         full_name = replace(full_name, key => value)
@@ -2852,7 +2852,7 @@ function shorten_ids_name(full_name::String; abbreviations::Dict=default_abbrevi
     return full_name
 end
 
-@recipe function plot_IFF(IFF::IDS_Field_Finder; abbreviations::Dict=default_abbreviations)
+@recipe function plot_IFF(IFF::IDS_Field_Finder)
     if Plots.backend_name() == :unicodeplots
         seriestype_3d = get(plotattributes, :seriestype_3d, :contour)
     else
@@ -2860,13 +2860,14 @@ end
     end
 
     seriestype_2d = get(plotattributes, :seriestype_2d, :line)
+    abbreviations = get(plotattributes, :abbreviations, default_abbreviations)
 
     id = plot_help_id(IFF)
     assert_type_and_record_argument(id, Dict, "Abbreviations to shorten titles of subplots"; abbreviations)
     assert_type_and_record_argument(id, Symbol, "Seriestype for 2D data [:line (default), :scatter, :bar ...]"; seriestype_2d)
     assert_type_and_record_argument(id, Symbol, "Seriestype for 3D data [:contourf (default), :contour, :surface, :heatmap]"; seriestype_3d)
 
-    filed_name = shorten_ids_name(IFF.field_path; abbreviations)
+    filed_name = shorten_ids_name(IFF.field_path, abbreviations)
 
     if IFF.field_type <: AbstractVector{<:Real} && length(IFF.value) > 0
         if length(IFF.value) == 1

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -2898,8 +2898,8 @@ end
             # Plot zvalue with the coordinates
             xvalue = coord.values[1]
             yvalue = coord.values[2]
-            xlabel --> "dim1"
-            ylabel --> "dim2"
+            xlabel --> split(coord.names[1], '.')[end] # dim1
+            ylabel --> split(coord.names[2], '.')[end] # dim2
 
             xlim --> (minimum(xvalue), maximum(xvalue))
             ylim --> (minimum(yvalue), maximum(yvalue))

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -2893,23 +2893,13 @@ end
 
         zvalue = getproperty(IFF.parent_ids, IFF.field)
 
-        # Check if the parend_ids has a valid grid
-        flag_valid_grid = false
-        if hasfield(typeof(IFF.parent_ids), :grid)
-            grid = getproperty(IFF.parent_ids, :grid)
-            flag_valid_grid = true
-            flag_valid_grid *= length(grid.dim1) == size(zvalue, 1)
-            flag_valid_grid *= length(grid.dim2) == size(zvalue, 2)
-            flag_valid_grid *= issorted(grid.dim1)
-            flag_valid_grid *= issorted(grid.dim2)
-        end
-
-        if flag_valid_grid
-            grid = getproperty(IFF.parent_ids, :grid)
-            xvalue = grid.dim1
-            yvalue = grid.dim2
-            xlabel --> "grid.dim1"
-            ylabel --> "grid.dim2"
+        coord = coordinates(IFF.parent_ids, IFF.field)
+        if ~isempty(coord.values) && issorted(coord.values[1]) && issorted(coord.values[2])
+            # Plot zvalue with the coordinates
+            xvalue = coord.values[1]
+            yvalue = coord.values[2]
+            xlabel --> "dim1"
+            ylabel --> "dim2"
 
             xlim --> (minimum(xvalue), maximum(xvalue))
             ylim --> (minimum(yvalue), maximum(yvalue))

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -35,6 +35,8 @@ function assert_type_and_record_argument(dispatch, type::Type, description::Stri
     argument = collect(keys(kw))[1]
     value = collect(values(kw))[1]
 
+    @assert typeof(value) <: type "\"$argument\" has the wrong type of [$(typeof(value))]. It must be a subtype of [$(type)]"
+
     this_plotpar = PlotHelpParameter(dispatch, argument, type, description, value)
 
     only_match = true


### PR DESCRIPTION
# Summary
This PR implements new `@recipes` for `IFF` (`IDS_Field_Finder`) structures.
The new recipes aim to plot multiple fields at once, i.e., multiple-subplots in a single figure, allowing users to quickly visualize and analyze the data of interest. 

Among the given IFF list, this recipe only plots either `AbstractVector{<:Real}` or `AbstractMatrix{<:Real}` data to avoid a possible conflict with other `@recipes` for specific IDS data.

- The new recipes have several optional arguments, which can be shown by `help_plot`.

# Feature description
There are two different fallbacks, depending on the datatype.

### 1.  `AbstractVector{<:Real}`
- This uses the existing recipe `@recipe function plot_field`
- Multiple fields call the `plot_field` recipe multiple times.

### 2. `AbstractMatrix{<:Real}`
- This calls one of the basic `seriestype` in the `Plots` package for 3-dimensional data `(x,y,z)`, such as `contourf`, `contour`, `heatmap`, and`surface`.
- Default `seriestype` is `contourf`, except for the `UnicodePlots` backend, where `contour` is set due to the compatibility issue.

# Optional arguments
- A recipe for `Vector{IMASdd.IDS_Field_Finder}`
  - `each_size`: Size of each subplot (Default = `(500,400)`)
  - `nrows`: Number of rows for subplots' layout (Default=`:auto`)
  - `ncols`: Number of columns for subplots' layout (Default=`:auto`)
  
- A recipe for `IMASdd.IDS_Field_Finder`
  - `abbreviations`: Abbreviations to shorten titles of subplots
  - `seriestype_2d`: Seriestype for 2D data (x,y)
  - `seriestype_3d`: Seriestype for 3D data (x,y,z)

See the following output with `help_plot` for example:

![Screenshot 2024-11-20 at 9 37 45 AM](https://github.com/user-attachments/assets/0a583d0e-e765-4ff1-9552-f427b23e6147)

# Examples
```julia
# Load IMASdd's sample json file
dd = IMAS.json2imas("IMASdd/sample/omas_sample.json"); 

# Find IFF and plot
IFF = findall(dd, [:psi, :j_tor]);
plot(IFF)

# There is a equivalent wrapper function for the user's convenience
plot(dd, [:psi,:j_tor]) # a wrapper for `findall` & `plot`
```

## 1. Default case
```julia
plot(dd, [:psi,:j_tor]) # a wrapper for `findall` & `plot`
```
![Screenshot 2024-11-19 at 5 36 54 PM](https://github.com/user-attachments/assets/69a6aad8-84bc-49e5-a69c-b1518002763c)

## 2. Control `each_size` and `ncols`
```julia
plot(dd, [:psi,:j_tor]; ncols=2, each_size=(300,300)) 
```
![Screenshot 2024-11-19 at 5 38 26 PM](https://github.com/user-attachments/assets/eb2b42af-759d-4368-8e5d-3819470c79bf)


## 3. `seriestype_3d` and `abbreviations`
 ```julia
# Use `Heatmap`for 3D data
# with no abbreviation for titles (by providing the empty `Dict`)
plot(dd, [:psi,:j_tor]; seriestype_3d=:heatmap, abbreviations=Dict()) 
```
![Screenshot 2024-11-19 at 5 39 20 PM](https://github.com/user-attachments/assets/55f78822-2745-43f0-9ba9-ac267fa77837)

## 4. More custom examples
```julia
# In addition to the `defulat_abbreviations`, 
# one can use the unicode or LaTexStrings for further polishing the titles
using LaTexStrings
new_abbrev = Dict(IMAS.default_abbreviations..., "psi"=>"ψ", "j_tor"=>L"j_{\phi}");
plot(dd, [:psi,:j_tor]; seriestype_2d=:bar, seriestype_3d=:surface, abbreviations=new_abbrev)
```

![Screenshot 2024-11-20 at 9 56 07 AM](https://github.com/user-attachments/assets/a4d84af0-e249-40b3-b4cb-3789e6f4f83e)

