### PR TITLE
Set the default `:linewidth` of 1.0 in the plot_balance_of_plant

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -2288,7 +2288,7 @@ end
 # balance_of_plant #
 # ================ #
 @recipe function plot_balance_of_plant(bop::IMAS.balance_of_plant)
-    base_linewidth = plotattributes[:linewidth]
+    base_linewidth = get(plotattributes, :linewidth, 1.0)
 
     size --> (800, 600)
     legend_position --> :outertopright


### PR DESCRIPTION
This is a quick fix for a bug described in the following issue:
https://github.com/ProjectTorreyPines/FUSE.jl/issues/786
- Backend/user interface
    Bug: help_plot(dd.balance_of_plant) throws an error with :linewidth attribute (key :linewidth not found)

This PR sets the default `:linewidth` of `1.0` in the `plot_balance_of_plant` recipe, if the `:linewidth` is not provided by the user. 
