### PR TITLE
IMAS changes to find_strike_points!

### DIFF
--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -712,33 +712,28 @@ push!(document[Symbol("Geometry")], :is_updown_symmetric)
         Z_obj2::AbstractVector{<:T};
         return_index::Bool=false) where {T<:Real}
 
-Returns minimum distance between two polygons vertices
+Returns minimum distance between two polygons vertices and index of points on the two polygons
 """
 function minimum_distance_polygons_vertices(
     R_obj1::AbstractVector{<:T},
     Z_obj1::AbstractVector{<:T},
     R_obj2::AbstractVector{<:T},
-    Z_obj2::AbstractVector{<:T};
-    return_index::Bool=false) where {T<:Real}
+    Z_obj2::AbstractVector{<:T}) where {T<:Real}
 
-    distance = Inf
+    distance2 = Inf
     ik1 = 0
     ik2 = 0
     for k1 in eachindex(R_obj1)
         for k2 in eachindex(R_obj2)
             @inbounds d = (R_obj1[k1] - R_obj2[k2])^2 + (Z_obj1[k1] - Z_obj2[k2])^2
-            if distance > d
+            if distance2 > d
                 ik1 = k1
                 ik2 = k2
-                distance = d
+                distance2 = d
             end
         end
     end
-    if return_index
-        return ik1, ik2
-    else
-        return sqrt(distance)
-    end
+    return (distance=sqrt(distance2), k1=ik1, k2=ik2)
 end
 
 @compat public minimum_distance_polygons_vertices

--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -616,19 +616,19 @@ function find_psi_last_diverted(
     ZA = eqt.global_quantities.magnetic_axis.z
 
     psi_axis = eqt.profiles_1d.psi[1] # psi value on axis\
-    psi_first_open = find_psi_boundary(eqt, wall_r, wall_z; raise_error_on_not_open=true).first_open
-    psi_sign = sign(psi_first_open - psi_axis) # +1 incresing psi / -1 decreasing psi
+    psi_boundaries = find_psi_boundary(eqt, wall_r, wall_z; raise_error_on_not_open=true)
+    psi_sign = sign(psi_boundaries.first_open - psi_axis) # +1 incresing psi / -1 decreasing psi
 
     # Case for limited plasmas
     psi_sep_closed, psi_sep_open = find_psi_separatrix(eqt)
 
-    if psi_sign * psi_sep_open > psi_sign * psi_first_open
+    if psi_sign * psi_sep_open > psi_sign * psi_boundaries.first_open
         # if the LCFS is not the magnetic separatrix
         # the plasma is limited and not diverted
         limited = true
         Xpoint2 = [eqt.boundary.x_point[1].r, eqt.boundary.x_point[1].z]
         psi_2ndseparatrix = psi_sep_open # psi first magnetic separatrix
-    # return (psi_last_lfs=psi_sep_closed, psi_first_open=psi_first_open,  psi_first_lfs_far=psi_sep_open, null_within_wall=true)
+    # return (psi_last_lfs=psi_sep_closed, psi_first_open=psi_boundaries.first_open,  psi_first_lfs_far=psi_sep_open, null_within_wall=true)
     else
         limited = false
         Xpoint2 = [eqt.boundary.x_point[end].r, eqt.boundary.x_point[end].z]
@@ -696,7 +696,7 @@ function find_psi_last_diverted(
     end
 
     if isempty(eqt.boundary.strike_point)
-        find_strike_points!(eqt, wall_r, wall_z, psi_first_open)
+        find_strike_points!(eqt, wall_r, wall_z, psi_boundaries.last_closed, psi_boundaries.first_open)
     end
 
     # find the two surfaces `psi_first_lfs_far` and `psi_last_lfs` around the last diverted flux surface
@@ -708,7 +708,7 @@ function find_psi_last_diverted(
         psi_first_lfs_far = psi_2ndseparatrix
     end
 
-    psi_last_lfs = psi_first_open
+    psi_last_lfs = psi_boundaries.first_open
     psi = (psi_first_lfs_far + psi_last_lfs) / 2
 
     counter_max = 100
@@ -804,7 +804,7 @@ function find_psi_last_diverted(
         psi_first_lfs_far = psi_sep_open
     end
 
-    return (psi_last_lfs=psi_last_lfs, psi_first_open=psi_first_open, psi_first_lfs_far=psi_first_lfs_far, null_within_wall=null_within_wall)
+    return (psi_last_lfs=psi_last_lfs, psi_first_open=psi_boundaries.first_open, psi_first_lfs_far=psi_first_lfs_far, null_within_wall=null_within_wall)
 end
 
 @compat public find_psi_last_diverted

--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -1653,9 +1653,6 @@ function flux_surfaces(eqt::equilibrium__time_slice{T1}, wall_r::AbstractVector{
             (eqt.profiles_1d.psi .- eqt.profiles_1d.psi[1]) ./ (eqt.profiles_1d.psi[end] - eqt.profiles_1d.psi[1]) .* (psi_boundaries.last_closed - psi_axis) .+ psi_axis
     end
 
-    # find strike points
-    find_strike_points!(eqt, wall_r, wall_z, psi_boundaries.first_open)
-
     for item in (
         :b_field_average,
         :b_field_max,
@@ -1875,6 +1872,9 @@ function flux_surfaces(eqt::equilibrium__time_slice{T1}, wall_r::AbstractVector{
             eqt.boundary_secondary_separatrix.outline.z = pts[1][2]
         end
     end
+
+    # find strike points
+    find_strike_points!(eqt, wall_r, wall_z, psi_boundaries.last_closed, psi_boundaries.first_open)
 
     return eqt
 end

--- a/src/physics/sol.jl
+++ b/src/physics/sol.jl
@@ -150,7 +150,13 @@ Returns vectors of hfs and lfs OpenFieldLine
 
 If levels is a vector, it has the values of psi from 0 to max psi_wall_midplane. The function will modify levels of psi to introduce relevant sol surfaces
 """
-function sol(eqt::IMAS.equilibrium__time_slice, wall_r::AbstractVector{T}, wall_z::AbstractVector{T}; levels::Union{Int,AbstractVector}=20, use_wall::Bool=!isempty(wall_r)) where {T<:Real}
+function sol(
+    eqt::IMAS.equilibrium__time_slice,
+    wall_r::AbstractVector{T},
+    wall_z::AbstractVector{T};
+    levels::Union{Int,AbstractVector}=20,
+    use_wall::Bool=!isempty(wall_r)
+) where {T<:Real}
     @assert length(wall_r) == length(wall_z)
     OFL = OrderedCollections.OrderedDict(:hfs => OpenFieldLine[], :lfs => OpenFieldLine[], :lfs_far => OpenFieldLine[])
 
@@ -566,7 +572,7 @@ function find_levels_from_wall(
     psi_tangent_in = find_psi_tangent_omp(eqt, wall_r, wall_z, PSI_interpolant).psi_tangent_in
     push!(levels, psi_tangent_in)
 
-    index = levels.>=psi_separatrix .&& levels.<=psi_wall_midplane
+    index = levels .>= psi_separatrix .&& levels .<= psi_wall_midplane
     levels = levels[index]
     sort!(levels)
 
@@ -1046,7 +1052,7 @@ push!(document[Symbol("Physics sol")], :q_par_omp_eich)
 
 Finds strike points and angles of incidence between two paths
 """
-function find_strike_points(pr::AbstractVector{T1}, pz::AbstractVector{T1}, wall_r::AbstractVector{T2}, wall_z::AbstractVector{T2}) where {T1<:Real, T2<:Real}
+function find_strike_points(pr::AbstractVector{T1}, pz::AbstractVector{T1}, wall_r::AbstractVector{T2}, wall_z::AbstractVector{T2}) where {T1<:Real,T2<:Real}
     indexes, crossings = intersection(wall_r, wall_z, pr, pz)
     Rxx = [cr[1] for cr in crossings]
     Zxx = [cr[2] for cr in crossings]
@@ -1059,19 +1065,21 @@ end
         eqt::IMAS.equilibrium__time_slice{T1},
         wall_r::AbstractVector{T2},
         wall_z::AbstractVector{2},
+        psi_last_closed::Real,
         psi_first_open::Union{T3,Nothing};
         strike_surfaces_r::AbstractVector{T4}=wall_r,
         strike_surfaces_z::AbstractVector{T4}=wall_z,
         private_flux_regions::Bool=true
     ) where {T1<:Real,T2<:Real,T3<:Real,T4<:Real}
 
-Finds equilibrium strike points, angle of incidence between wall and strike leg, and 
+Finds equilibrium strike points, angle of incidence between wall and strike leg, and
 the minimum distance between the surface where a strike point is located (both private and encircling) and the last closed flux surface (encircling)
 """
 function find_strike_points(
     eqt::IMAS.equilibrium__time_slice{T1},
     wall_r::AbstractVector{T2},
     wall_z::AbstractVector{T2},
+    psi_last_closed::Real,
     psi_first_open::Union{T3,Nothing};
     strike_surfaces_r::AbstractVector{T4}=wall_r,
     strike_surfaces_z::AbstractVector{T4}=wall_z,
@@ -1086,8 +1094,11 @@ function find_strike_points(
     if !isempty(wall_r)
         # find separatrix as first surface in SOL, not in private region
         if psi_first_open !== nothing
-            first_open = flux_surface(eqt, psi_first_open, :encircling, Float64[], Float64[])[1]
-            sep = flux_surface(eqt, psi_first_open, :any, Float64[], Float64[])
+            bnd = flux_surface(eqt, psi_last_closed, :closed, wall_r, wall_z)[1]
+            sep = flux_surface(eqt, psi_last_closed, :open, wall_r, wall_z)
+            if isempty(sep)
+                sep = flux_surface(eqt, psi_first_open, :open, wall_r, wall_z)
+            end
             zaxis = eqt.boundary.geometric_axis.z
             for (pr, pz) in sep
                 if isempty(pr)
@@ -1103,64 +1114,57 @@ function find_strike_points(
                 end
                 Rxx_, Zx_, θx_ = find_strike_points(pr, pz, strike_surfaces_r, strike_surfaces_z)
                 # compute dxx
-                dx_ = min_mean_distance_polygons(pr,pz,first_open.r,first_open.z).min_distance
+                dx_, k1, k2 = minimum_distance_polygons_vertices(pr, pz, bnd.r, bnd.z)
 
                 # if there are more than 2 strike points per surface, filter shadowed strike-points
                 if length(Rxx_) > 2
-                    if dx_ == 0.0
-                        # we are on the first open encircling surface (where the X-point is)
-                        # pick intersections closest to primary X-point
-                        # find primary x-point: the one with sign(Zx) equal to sign(first_open.z[1]) || sign(first_open.z[end])
-                        X = Vector{Float64}(undef,2)
-                        for point in eqt.boundary.x_point
-                            if sign(point.z) == sign(first_open.z[1])
-                                X = [point.r, point.z] # primary X-point
-                                break # x-points are ordered, we pick only the first with the same sign
-                            end
-                        end
-                    else
-                        # we are on a private surface
-                        # pick intersections closest to the "center" of flux surface
-                        X = [pr[floor(length(pr)/2)],pz[floor(length(pr)/2)] ]
-                    end
+                    X = (pr[k1], pz[k1])
+
+                    Rs = Float64[]
+                    Zs = Float64[]
+                    θs = Float64[]
 
                     # inner leg, all points with R < R point
-                    index = Rxx_ .< X[1]
-                    dist = (Rxx_[index] .- X[1]).^2 + (Zx_[index] .- X[2]).^2  #pick closest
-                    Rs = [Rxx_[index][argmin(dist)]]
-                    Zs = [ Zx_[index][argmin(dist)]]
-                    θs = [ θx_[index][argmin(dist)]]
+                    index = Rxx_ .<= X[1]
+                    dist = (Rxx_[index] .- X[1]) .^ 2 .+ (Zx_[index] .- X[2]) .^ 2  #pick closest
+                    if !isempty(dist)
+                        append!(Rs, Rxx_[index][argmin(dist)])
+                        append!(Zs, Zx_[index][argmin(dist)])
+                        append!(θs, θx_[index][argmin(dist)])
+                    end
 
                     # outer leg, all points with R > R point
-                    index = Rxx_ .> X[1]
-                    dist = (Rxx_[index] .- X[1]).^2 + (Zx_[index] .- X[2]).^2  #pick closest
-                    append!(Rs, Rxx_[index][argmin(dist)])
-                    append!(Zs,  Zx_[index][argmin(dist)])
-                    append!(θs,  θx_[index][argmin(dist)])
-                    
+                    index = Rxx_ .>= X[1]
+                    dist = (Rxx_[index] .- X[1]) .^ 2 .+ (Zx_[index] .- X[2]) .^ 2  #pick closest
+                    if !isempty(dist)
+                        append!(Rs, Rxx_[index][argmin(dist)])
+                        append!(Zs, Zx_[index][argmin(dist)])
+                        append!(θs, θx_[index][argmin(dist)])
+                    end
+
                     # update with filtered values
                     Rxx_ = Rs
-                    Zx_  = Zs
-                    θx_  = θs
+                    Zx_ = Zs
+                    θx_ = θs
                 end
 
                 # save strike-points in clockwise order. Note: from here on, length(Rxx_) = 2
                 if pz[1] > zaxis
                     # upper single null: clockwise means outer than inner
-                    Zx_  =  Zx_[reverse(sortperm(Rxx_))]
-                    θx_  =  θx_[reverse(sortperm(Rxx_))]
-                    Rxx_ = Rxx_[reverse(sortperm(Rxx_))]                    
+                    Zx_ = Zx_[reverse(sortperm(Rxx_))]
+                    θx_ = θx_[reverse(sortperm(Rxx_))]
+                    Rxx_ = Rxx_[reverse(sortperm(Rxx_))]
                 else
                     # lower single null: clockwise means inner than outer
-                    Zx_  =  Zx_[sortperm(Rxx_)]
-                    θx_  =  θx_[sortperm(Rxx_)]
+                    Zx_ = Zx_[sortperm(Rxx_)]
+                    θx_ = θx_[sortperm(Rxx_)]
                     Rxx_ = Rxx_[sortperm(Rxx_)]
                 end
 
                 append!(Rxx, Rxx_)
                 append!(Zxx, Zx_)
                 append!(θxx, θx_)
-                append!(dxx, dx_.*ones(length(Rxx_)))
+                append!(dxx, dx_ .* ones(length(Rxx_)))
             end
         end
     end
@@ -1176,6 +1180,7 @@ push!(document[Symbol("Physics sol")], :find_strike_points)
         eqt::IMAS.equilibrium__time_slice{T1},
         wall_r::AbstractVector{T2},
         wall_z::AbstractVector{T2},
+        psi_last_closed::Real,
         psi_first_open::Union{T3,Nothing},
         dv::IMAS.divertors{T1};
         private_flux_regions::Bool=true,
@@ -1188,6 +1193,7 @@ function find_strike_points!(
     eqt::IMAS.equilibrium__time_slice{T1},
     wall_r::AbstractVector{T2},
     wall_z::AbstractVector{T2},
+    psi_last_closed::Real,
     psi_first_open::Union{T3,Nothing},
     dv::IMAS.divertors{T1};
     private_flux_regions::Bool=true,
@@ -1207,6 +1213,7 @@ function find_strike_points!(
                 eqt,
                 wall_r,
                 wall_z,
+                psi_last_closed,
                 psi_first_open;
                 private_flux_regions,
                 strike_surfaces_r=target.tile[1].surface_outline.r,
@@ -1243,6 +1250,7 @@ end
         eqt::IMAS.equilibrium__time_slice{T1},
         wall_r::AbstractVector{T2},
         wall_z::AbstractVector{T2},
+        psi_last_closed::Real,
         psi_first_open::Union{T3,Nothing},
         dv::IMAS.divertors{T1};
         private_flux_regions::Bool=true
@@ -1254,12 +1262,13 @@ function find_strike_points(
     eqt::IMAS.equilibrium__time_slice{T1},
     wall_r::AbstractVector{T2},
     wall_z::AbstractVector{T2},
+    psi_last_closed::Real,
     psi_first_open::Union{T3,Nothing},
     dv::IMAS.divertors{T1};
     private_flux_regions::Bool=true
 ) where {T1<:Real,T2<:Real,T3<:Real}
 
-    return find_strike_points!(eqt, wall_r, wall_z, psi_first_open, dv; private_flux_regions, in_place=false)
+    return find_strike_points!(eqt, wall_r, wall_z, psi_last_closed, psi_first_open, dv; private_flux_regions, in_place=false)
 end
 
 """
@@ -1267,6 +1276,7 @@ end
         eqt::IMAS.equilibrium__time_slice{T1},
         wall_r::AbstractVector{T2},
         wall_z::AbstractVector{T2},
+        psi_last_closed::Real,
         psi_first_open::T3
     ) where {T1<:Real,T2<:Real,T3<:Real}
 """
@@ -1274,10 +1284,11 @@ function find_strike_points!(
     eqt::IMAS.equilibrium__time_slice{T1},
     wall_r::AbstractVector{T2},
     wall_z::AbstractVector{T2},
+    psi_last_closed::Real,
     psi_first_open::T3
 ) where {T1<:Real,T2<:Real,T3<:Real}
 
-    Rxx, Zxx, θxx, dxx = find_strike_points(eqt, wall_r, wall_z, psi_first_open)
+    Rxx, Zxx, θxx, dxx = find_strike_points(eqt, wall_r, wall_z, psi_last_closed, psi_first_open)
     resize!(eqt.boundary.strike_point, length(Rxx))
     for (k, strike_point) in enumerate(eqt.boundary.strike_point)
         strike_point.r = Rxx[k]
@@ -1293,6 +1304,7 @@ end
         eqt::IMAS.equilibrium__time_slice{T1},
         wall_r::AbstractVector{T2},
         wall_z::AbstractVector{T2},
+        psi_last_closed::Real,
         psi_first_open::Nothing
     ) where {T1<:Real,T2<:Real}
 """
@@ -1300,6 +1312,7 @@ function find_strike_points!(
     eqt::IMAS.equilibrium__time_slice{T1},
     wall_r::AbstractVector{T2},
     wall_z::AbstractVector{T2},
+    psi_last_closed::Real,
     psi_first_open::Nothing
 ) where {T1<:Real,T2<:Real}
     return (Rxx=Float64[], Zxx=Float64[], θxx=Float64[], dxx=Float64[])

--- a/src/physics/sol.jl
+++ b/src/physics/sol.jl
@@ -1304,15 +1304,15 @@ end
         eqt::IMAS.equilibrium__time_slice{T1},
         wall_r::AbstractVector{T2},
         wall_z::AbstractVector{T2},
-        psi_last_closed::Real,
+        psi_last_closed::Union{Real,Nothing},
         psi_first_open::Nothing
-    ) where {T1<:Real,T2<:Real}
+    )
 """
 function find_strike_points!(
     eqt::IMAS.equilibrium__time_slice{T1},
     wall_r::AbstractVector{T2},
     wall_z::AbstractVector{T2},
-    psi_last_closed::Real,
+    psi_last_closed::Union{Real,Nothing},
     psi_first_open::Nothing
 ) where {T1<:Real,T2<:Real}
     return (Rxx=Float64[], Zxx=Float64[], θxx=Float64[], dxx=Float64[])

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -863,7 +863,7 @@ end
 # build #
 # ===== #
 function join_outlines(r1::AbstractVector{T}, z1::AbstractVector{T}, r2::AbstractVector{T}, z2::AbstractVector{T}) where {T<:Real}
-    i1, i2 = minimum_distance_polygons_vertices(r1, z1, r2, z2; return_index=true)
+    distance, i1, i2 = minimum_distance_polygons_vertices(r1, z1, r2, z2)
     r = vcat(reverse(r1[i1:end]), r2[i2:end], r2[1:i2], reverse(r1[1:i1]))
     z = vcat(reverse(z1[i1:end]), z2[i2:end], z2[1:i2], reverse(z1[1:i1]))
     return r, z


### PR DESCRIPTION
I found cases where the new IMAS.find_strike_points was failing, specifically D3D where the private flux region was grazing the wall like when working with `ini, act = FUSE.case_parameters(:D3D, 170325)`. These updates seem to generate robust strike points.

@ggdose it would be good for you to test it with the notebook you've been using for development of SOL routines.