### PR TITLE
Fix find x points and find surf

### DIFF
--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -430,7 +430,7 @@ function find_psi_boundary(
                 display(plot!(pr, pz; label="", color=:green))
             end
             psirange[1] = psimid
-            if (abs(psirange[end] - psirange[1]) / abs(psirange[end] + psirange[1]) / 2.0) < precision
+            if (abs(psirange[end] - psirange[1]) / (abs(psirange[end] + psirange[1]) / 2.0)) < precision
                 return (last_closed=psimid, first_open=psirange[end])
             end
             # open flux surface

--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -3,6 +3,9 @@ document[Symbol("Physics flux-surfaces")] = Symbol[]
 using LinearAlgebra
 using Plots
 
+# setting global variable for precision for computing relevant surfaces (i.e. lcfs, first_open, ldfs, 1st sep, 2nd sep,..)
+const flux_surfaces_precision::Float64=1E-6
+
 """
     ψ_interpolant(eqt2d::IMAS.equilibrium__time_slice___profiles_2d)
 
@@ -160,7 +163,7 @@ push!(document[Symbol("Physics flux-surfaces")], :Bp)
         eqt::IMAS.equilibrium__time_slice{T},
         wall_r::AbstractVector{T},
         wall_z::AbstractVector{T};
-        precision::Float64=1e-6,
+        precision::Float64=flux_surfaces_precision,
         raise_error_on_not_open::Bool=true,
         raise_error_on_not_closed::Bool=true
     ) where {T<:Real}
@@ -173,7 +176,7 @@ function find_psi_boundary(
     eqt::IMAS.equilibrium__time_slice{T},
     wall_r::AbstractVector{T},
     wall_z::AbstractVector{T};
-    precision::Float64=1e-6,
+    precision::Float64=flux_surfaces_precision,
     raise_error_on_not_open::Bool=true,
     raise_error_on_not_closed::Bool=true) where {T<:Real}
 
@@ -204,7 +207,7 @@ end
         fw_r::AbstractVector{T4},
         fw_z::AbstractVector{T5};
         PSI_interpolant=IMAS.ψ_interpolant(dimR, dimZ, PSI).PSI_interpolant,
-        precision::Float64=1e-6,
+        precision::Float64=flux_surfaces_precision,
         raise_error_on_not_open::Bool,
         raise_error_on_not_closed::Bool,
         verbose::Bool=false
@@ -223,7 +226,7 @@ function find_psi_boundary(
     r_cache::AbstractVector{T1}=T1[],
     z_cache::AbstractVector{T1}=T1[];
     PSI_interpolant=IMAS.ψ_interpolant(dimR, dimZ, PSI).PSI_interpolant,
-    precision::Float64=1e-6,
+    precision::Float64=flux_surfaces_precision,
     raise_error_on_not_open::Bool,
     raise_error_on_not_closed::Bool,
     verbose::Bool=false
@@ -284,7 +287,7 @@ end
         r_cache::AbstractVector{T1}=T1[],
         z_cache::AbstractVector{T1}=T1[];
         PSI_interpolant=IMAS.ψ_interpolant(dimR, dimZ, PSI).PSI_interpolant,
-        precision::Float64=1e-6,
+        precision::Float64=flux_surfaces_precision,
         raise_error_on_not_open::Bool,
         raise_error_on_not_closed::Bool,
         verbose::Bool=false
@@ -303,7 +306,7 @@ function find_psi_boundary(
     r_cache::AbstractVector{T1}=T1[],
     z_cache::AbstractVector{T1}=T1[];
     PSI_interpolant=IMAS.ψ_interpolant(dimR, dimZ, PSI).PSI_interpolant,
-    precision::Float64=1e-6,
+    precision::Float64=flux_surfaces_precision,
     raise_error_on_not_open::Bool,
     raise_error_on_not_closed::Bool,
     verbose::Bool=false
@@ -353,7 +356,7 @@ end
         r_cache::AbstractVector{T1}=T1[],
         z_cache::AbstractVector{T1}=T1[];
         PSI_interpolant=IMAS.ψ_interpolant(dimR, dimZ, PSI).PSI_interpolant,
-        precision::Float64=1e-6,
+        precision::Float64=flux_surfaces_precision,
         raise_error_on_not_open::Bool,
         raise_error_on_not_closed::Bool,
         verbose::Bool=false
@@ -371,7 +374,7 @@ function find_psi_boundary(
     r_cache::AbstractVector{T1}=T1[],
     z_cache::AbstractVector{T1}=T1[];
     PSI_interpolant=IMAS.ψ_interpolant(dimR, dimZ, PSI).PSI_interpolant,
-    precision::Float64=1e-6,
+    precision::Float64=flux_surfaces_precision,
     raise_error_on_not_open::Bool,
     raise_error_on_not_closed::Bool,
     verbose::Bool=false
@@ -458,14 +461,14 @@ function is_closed_surface(pr::AbstractVector{T}, pz::AbstractVector{T}, fw_r::A
 end
 
 """
-    find_psi_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision::Float64=1E-7) where {T<:Real}
+    find_psi_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision::Float64=flux_surfaces_precision) where {T<:Real}
 
 Returns psi of the first magentic separatrix
 
 Note: The first separatrix is the LCFS only in diverted plasmas
 """
-function find_psi_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision::Float64=1E-7) where {T<:Real}
     psi_up = find_psi_2nd_separatrix(eqt; type=:diverted)
+function find_psi_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision::Float64=flux_surfaces_precision) where {T<:Real}
     psi_low = eqt.profiles_1d.psi[1]
 
     psi = (psi_up + psi_low) / 2.0
@@ -500,7 +503,7 @@ end
 push!(document[Symbol("Physics flux-surfaces")], :find_psi_separatrix)
 
 """
-    find_psi_2nd_separatrix(eqt::IMAS.equilibrium__time_slice{T}; type::Symbol=:not_diverted, precision::Float64=1E-7) where {T<:Real}
+    find_psi_2nd_separatrix(eqt::IMAS.equilibrium__time_slice{T}; type::Symbol=:not_diverted, precision::Float64=flux_surfaces_precision) where {T<:Real}
 
 Returns psi of the second magentic separatrix
 
@@ -590,7 +593,7 @@ push!(document[Symbol("Physics flux-surfaces")], :find_psi_2nd_separatrix)
         wall_r::AbstractVector{<:Real},
         wall_z::AbstractVector{<:Real},
         PSI_interpolant::Interpolations.AbstractInterpolation;
-        precision::Float64=1e-7)
+        precision::Float64=flux_surfaces_precision)
 
 Returns `psi_last_lfs, `psi_first_lfs_far`, and `null_within_wall`
 
@@ -605,7 +608,7 @@ function find_psi_last_diverted(
     wall_r::AbstractVector{<:Real},
     wall_z::AbstractVector{<:Real},
     PSI_interpolant::Interpolations.AbstractInterpolation;
-    precision::Float64=1e-7)
+    precision::Float64=flux_surfaces_precision)
 
     # if no wall in dd, psi_last diverted not defined
     if isempty(wall_r) || isempty(wall_z) || isempty(eqt.boundary.x_point)
@@ -816,7 +819,7 @@ push!(document[Symbol("Physics flux-surfaces")], :find_psi_last_diverted)
         wall_r::AbstractVector{<:Real},
         wall_z::AbstractVector{<:Real},
         PSI_interpolant::Interpolations.AbstractInterpolation;
-        precision::Float64=1e-7)
+        precision::Float64=flux_surfaces_precision)
 
 Returns the psi of the magnetic surface in the SOL which is tangent to the wall near the outer midplane
 """
@@ -825,7 +828,7 @@ function find_psi_tangent_omp(
     wall_r::AbstractVector{<:Real},
     wall_z::AbstractVector{<:Real},
     PSI_interpolant::Interpolations.AbstractInterpolation;
-    precision::Float64=1e-7)
+    precision::Float64=flux_surfaces_precision)
 
     psi_max = find_psi_max(eqt)
 

--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -520,8 +520,12 @@ function find_psi_2nd_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision
 
     # First check if we are in a double null configuration
     ZA = eqt.global_quantities.magnetic_axis.z
+    # retrieve b = elongation * minor radius 
+    b = eqt.boundary.elongation * eqt.boundary.minor_radius
+   
     for (r, z) in surface
-        if isempty(r) || all(z .> ZA) || all(z .< ZA) # exclude private region and empty vectors
+        # exclude empty vectors, private region and surfaces starting and finishing in the same z range as the plasma
+        if isempty(r) || all(z .> ZA) || all(z .< ZA) || all(z .> (ZA - b) .&& z .< (ZA + b))  
             continue
         end
         if (z[end] - ZA) * (z[1] - ZA) < 0
@@ -559,7 +563,7 @@ function find_psi_2nd_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision
     while abs(err) > precision && counter < counter_max
         surface = flux_surface(eqt, psi, :open, Float64[], Float64[])
         for (r, z) in surface
-            if isempty(r) || all(z .> ZA) || all(z .< ZA)
+            if isempty(r) || all(z .> ZA) || all(z .< ZA) || all(z .> (ZA - b) .&& z .< (ZA + b)) 
                 continue
             end
 

--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -532,10 +532,10 @@ function find_psi_2nd_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision
             # abs(psirange[end] - psirange[1]) / (abs(psirange[end] + psirange[1]) / 2.0) < precision
             if psi_sign > 0
                 #increasing psi
-                return (diverted = psi_separatrix, not_diverted = psi_spearatrix*(1+flux_surfaces_precision))
+                return (diverted = psi_separatrix, not_diverted = psi_separatrix*(1+flux_surfaces_precision))
             else
                 #decreasing psi
-                return (diverted = psi_separatrix, not_diverted = psi_spearatrix*(1-flux_surfaces_precision))
+                return (diverted = psi_separatrix, not_diverted = psi_separatrix*(1-flux_surfaces_precision))
             end
         end
     end

--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -525,8 +525,18 @@ function find_psi_2nd_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision
             continue
         end
         if (z[end] - ZA) * (z[1] - ZA) < 0
-            #if double null, all open surfaces in the SOL start and finish in opposite sides of the midplane
-            return psi_separatrix
+            # if perfect double null, all open surfaces in the SOL start and finish in opposite sides of the midplane
+            psi_axis = eqt.profiles_1d.psi[1] # psi value on axis
+            psi_sign = sign(psi_separatrix - psi_axis) # +1 for increasing psi / -1 for decreasing psi
+            # return psi_2ndsep = psi_lcfs, using same convergence criteria as in find_psi_boundary (~ line 436): 
+            # abs(psirange[end] - psirange[1]) / (abs(psirange[end] + psirange[1]) / 2.0) < precision
+            if psi_sign > 0
+                #increasing psi
+                return (diverted = psi_separatrix, not_diverted = psi_spearatrix*(1+flux_surfaces_precision))
+            else
+                #decreasing psi
+                return (diverted = psi_separatrix, not_diverted = psi_spearatrix*(1-flux_surfaces_precision))
+            end
         end
     end
 

--- a/src/physics/sol.jl
+++ b/src/physics/sol.jl
@@ -176,7 +176,7 @@ function sol(eqt::IMAS.equilibrium__time_slice, wall_r::AbstractVector{T}, wall_
     end
 
     # find psi at second magnetic separatrix
-    psi__2nd_separatix = find_psi_2nd_separatrix(eqt; type=:not_diverted) # find psi at 2nd magnetic separatrix
+    psi__2nd_separatix = find_psi_2nd_separatrix(eqt).not_diverted # find psi at 2nd magnetic separatrix
     psi_sign = sign(psi__boundary_level - psi__axis_level) # sign of the poloidal flux taking psi_axis = 0
     psi_max = find_psi_max(eqt)
 
@@ -345,7 +345,7 @@ function find_levels_from_P(
     end
 
     psi__boundary_level = find_psi_boundary(eqt, wall_r, wall_z; raise_error_on_not_open=true).first_open # psi at LCFS
-    psi_2ndseparatrix = find_psi_2nd_separatrix(eqt; type=:not_diverted) # psi of the second magnetic separatrix
+    psi_2ndseparatrix = find_psi_2nd_separatrix(eqt).not_diverted # psi of the second magnetic separatrix
     if psi_sign > 0
         r_separatrix_midplane = r_mid(psi__boundary_level)      # R OMP at separatrix
         r_2ndseparatrix_midplane = r_mid(psi_2ndseparatrix) # R coordinate at OMP of 2nd magnetic separatrix

--- a/src/physics/thermal_loads.jl
+++ b/src/physics/thermal_loads.jl
@@ -82,7 +82,9 @@ function particle_heat_flux(
 
     q_interp = interp1d(r, q, :cubic)
 
-    if eqt.boundary.x_point[1].z < ZA
+    # to determine if upper or lower single null, check if Z(strike_point) < Z(axis)
+    # SOL[:lfs][1] = LCFS
+    if SOL[:lfs][1].z[1]< ZA
         case = :lower
     else
         case = :upper
@@ -504,7 +506,9 @@ function mesher_heat_flux(dd::IMAS.dd;
     Zwall = Float64[]
     indexes = Int64[]
 
-    if eqt.boundary.x_point[1].z < Z0
+    # to determine if upper or lower single null, check if Z(strike_point) < Z(axis)
+    # SOL[:lfs][1] = LCFS
+    if SOL[:lfs][1].z[1]< Z0 
         case = :lower
     else
         case = :upper


### PR DESCRIPTION
Several improvements:

- find_x_points could confuse the order of the x-points (for which we have a convention) when close to double null. This is because the distance in psi of the nulls was smaller than the precision of PSI_interpolant. By checking the strike points, this confusion is avoided.
- Fix of a number of bugs in several find_psi_XXX function. Moreover, find_psi_2ndseparatrix now returns a named tuple for diverted/not diverted case.