### PR TITLE
Fix strike points

### DIFF
--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -331,8 +331,12 @@ function intersection_split(
                 z[j+1] = getindex_circular(l1_y, ind)
             end
             r[end], z[end] = crossings[kk]
-
-            segments[k] = (r=r, z=z)
+            # if segment is made only of intersections, put a point in the middle of the segment
+            if length(r) == 2
+                segments[k] = (r=[r[1],(r[1] + r[end])/2, r[end]], z=[z[1],(z[1] + z[end])/2, z[end]])
+            else
+                segments[k] = (r=r, z=z)
+            end
         end
     end
 

--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -430,7 +430,7 @@ function find_psi_boundary(
                 display(plot!(pr, pz; label="", color=:green))
             end
             psirange[1] = psimid
-            if (abs(psirange[end] - psirange[1]) / abs(psirange[end] + psirange[1]) / 2.0) < precision
+            if (abs(psirange[end] - psirange[1]) / (abs(psirange[end] + psirange[1]) / 2.0)) < precision
                 return (last_closed=psimid, first_open=psirange[end])
             end
             # open flux surface

--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -3,6 +3,9 @@ document[Symbol("Physics flux-surfaces")] = Symbol[]
 using LinearAlgebra
 using Plots
 
+# setting global variable for precision for computing relevant surfaces (i.e. lcfs, first_open, ldfs, 1st sep, 2nd sep,..)
+const flux_surfaces_precision::Float64=1E-6
+
 """
     ψ_interpolant(eqt2d::IMAS.equilibrium__time_slice___profiles_2d)
 
@@ -160,7 +163,7 @@ push!(document[Symbol("Physics flux-surfaces")], :Bp)
         eqt::IMAS.equilibrium__time_slice{T},
         wall_r::AbstractVector{T},
         wall_z::AbstractVector{T};
-        precision::Float64=1e-6,
+        precision::Float64=flux_surfaces_precision,
         raise_error_on_not_open::Bool=true,
         raise_error_on_not_closed::Bool=true
     ) where {T<:Real}
@@ -173,7 +176,7 @@ function find_psi_boundary(
     eqt::IMAS.equilibrium__time_slice{T},
     wall_r::AbstractVector{T},
     wall_z::AbstractVector{T};
-    precision::Float64=1e-6,
+    precision::Float64=flux_surfaces_precision,
     raise_error_on_not_open::Bool=true,
     raise_error_on_not_closed::Bool=true) where {T<:Real}
 
@@ -204,7 +207,7 @@ end
         fw_r::AbstractVector{T4},
         fw_z::AbstractVector{T5};
         PSI_interpolant=IMAS.ψ_interpolant(dimR, dimZ, PSI).PSI_interpolant,
-        precision::Float64=1e-6,
+        precision::Float64=flux_surfaces_precision,
         raise_error_on_not_open::Bool,
         raise_error_on_not_closed::Bool,
         verbose::Bool=false
@@ -223,7 +226,7 @@ function find_psi_boundary(
     r_cache::AbstractVector{T1}=T1[],
     z_cache::AbstractVector{T1}=T1[];
     PSI_interpolant=IMAS.ψ_interpolant(dimR, dimZ, PSI).PSI_interpolant,
-    precision::Float64=1e-6,
+    precision::Float64=flux_surfaces_precision,
     raise_error_on_not_open::Bool,
     raise_error_on_not_closed::Bool,
     verbose::Bool=false
@@ -284,7 +287,7 @@ end
         r_cache::AbstractVector{T1}=T1[],
         z_cache::AbstractVector{T1}=T1[];
         PSI_interpolant=IMAS.ψ_interpolant(dimR, dimZ, PSI).PSI_interpolant,
-        precision::Float64=1e-6,
+        precision::Float64=flux_surfaces_precision,
         raise_error_on_not_open::Bool,
         raise_error_on_not_closed::Bool,
         verbose::Bool=false
@@ -303,7 +306,7 @@ function find_psi_boundary(
     r_cache::AbstractVector{T1}=T1[],
     z_cache::AbstractVector{T1}=T1[];
     PSI_interpolant=IMAS.ψ_interpolant(dimR, dimZ, PSI).PSI_interpolant,
-    precision::Float64=1e-6,
+    precision::Float64=flux_surfaces_precision,
     raise_error_on_not_open::Bool,
     raise_error_on_not_closed::Bool,
     verbose::Bool=false
@@ -353,7 +356,7 @@ end
         r_cache::AbstractVector{T1}=T1[],
         z_cache::AbstractVector{T1}=T1[];
         PSI_interpolant=IMAS.ψ_interpolant(dimR, dimZ, PSI).PSI_interpolant,
-        precision::Float64=1e-6,
+        precision::Float64=flux_surfaces_precision,
         raise_error_on_not_open::Bool,
         raise_error_on_not_closed::Bool,
         verbose::Bool=false
@@ -371,7 +374,7 @@ function find_psi_boundary(
     r_cache::AbstractVector{T1}=T1[],
     z_cache::AbstractVector{T1}=T1[];
     PSI_interpolant=IMAS.ψ_interpolant(dimR, dimZ, PSI).PSI_interpolant,
-    precision::Float64=1e-6,
+    precision::Float64=flux_surfaces_precision,
     raise_error_on_not_open::Bool,
     raise_error_on_not_closed::Bool,
     verbose::Bool=false
@@ -458,14 +461,14 @@ function is_closed_surface(pr::AbstractVector{T}, pz::AbstractVector{T}, fw_r::A
 end
 
 """
-    find_psi_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision::Float64=1E-7) where {T<:Real}
+    find_psi_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision::Float64=flux_surfaces_precision) where {T<:Real}
 
 Returns psi of the first magentic separatrix
 
 Note: The first separatrix is the LCFS only in diverted plasmas
 """
-function find_psi_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision::Float64=1E-7) where {T<:Real}
     psi_up = find_psi_2nd_separatrix(eqt; type=:diverted)
+function find_psi_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision::Float64=flux_surfaces_precision) where {T<:Real}
     psi_low = eqt.profiles_1d.psi[1]
 
     psi = (psi_up + psi_low) / 2.0
@@ -500,7 +503,7 @@ end
 push!(document[Symbol("Physics flux-surfaces")], :find_psi_separatrix)
 
 """
-    find_psi_2nd_separatrix(eqt::IMAS.equilibrium__time_slice{T}; type::Symbol=:not_diverted, precision::Float64=1E-7) where {T<:Real}
+    find_psi_2nd_separatrix(eqt::IMAS.equilibrium__time_slice{T}; type::Symbol=:not_diverted, precision::Float64=flux_surfaces_precision) where {T<:Real}
 
 Returns psi of the second magentic separatrix
 
@@ -590,7 +593,7 @@ push!(document[Symbol("Physics flux-surfaces")], :find_psi_2nd_separatrix)
         wall_r::AbstractVector{<:Real},
         wall_z::AbstractVector{<:Real},
         PSI_interpolant::Interpolations.AbstractInterpolation;
-        precision::Float64=1e-7)
+        precision::Float64=flux_surfaces_precision)
 
 Returns `psi_last_lfs, `psi_first_lfs_far`, and `null_within_wall`
 
@@ -605,7 +608,7 @@ function find_psi_last_diverted(
     wall_r::AbstractVector{<:Real},
     wall_z::AbstractVector{<:Real},
     PSI_interpolant::Interpolations.AbstractInterpolation;
-    precision::Float64=1e-7)
+    precision::Float64=flux_surfaces_precision)
 
     # if no wall in dd, psi_last diverted not defined
     if isempty(wall_r) || isempty(wall_z) || isempty(eqt.boundary.x_point)
@@ -816,7 +819,7 @@ push!(document[Symbol("Physics flux-surfaces")], :find_psi_last_diverted)
         wall_r::AbstractVector{<:Real},
         wall_z::AbstractVector{<:Real},
         PSI_interpolant::Interpolations.AbstractInterpolation;
-        precision::Float64=1e-7)
+        precision::Float64=flux_surfaces_precision)
 
 Returns the psi of the magnetic surface in the SOL which is tangent to the wall near the outer midplane
 """
@@ -825,7 +828,7 @@ function find_psi_tangent_omp(
     wall_r::AbstractVector{<:Real},
     wall_z::AbstractVector{<:Real},
     PSI_interpolant::Interpolations.AbstractInterpolation;
-    precision::Float64=1e-7)
+    precision::Float64=flux_surfaces_precision)
 
     psi_max = find_psi_max(eqt)
 

--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -520,8 +520,12 @@ function find_psi_2nd_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision
 
     # First check if we are in a double null configuration
     ZA = eqt.global_quantities.magnetic_axis.z
+    # retrieve b = elongation * minor radius 
+    b = eqt.boundary.elongation * eqt.boundary.minor_radius
+   
     for (r, z) in surface
-        if isempty(r) || all(z .> ZA) || all(z .< ZA) # exclude private region and empty vectors
+        # exclude empty vectors, private region and surfaces starting and finishing in the same z range as the plasma
+        if isempty(r) || all(z .> ZA) || all(z .< ZA) || all(z .> (ZA - b) .&& z .< (ZA + b))  
             continue
         end
         if (z[end] - ZA) * (z[1] - ZA) < 0
@@ -559,7 +563,7 @@ function find_psi_2nd_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision
     while abs(err) > precision && counter < counter_max
         surface = flux_surface(eqt, psi, :open, Float64[], Float64[])
         for (r, z) in surface
-            if isempty(r) || all(z .> ZA) || all(z .< ZA)
+            if isempty(r) || all(z .> ZA) || all(z .< ZA) || all(z .> (ZA - b) .&& z .< (ZA + b)) 
                 continue
             end
 

--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -1876,7 +1876,7 @@ function flux_surfaces(eqt::equilibrium__time_slice{T1}, wall_r::AbstractVector{
 
     # secondary separatrix
     if length(eqt.boundary.x_point) > 1
-        psi2nd = find_psi_2nd_separatrix(eqt).not_diverted
+        psi2nd = find_psi_2nd_separatrix(eqt).diverted
         pts = flux_surface(r, z, eqt2d.psi, RA, ZA, wall_r, wall_z, psi2nd, :encircling)
         if !isempty(pts)
             eqt.boundary_secondary_separatrix.outline.r = pts[1][1]

--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -532,10 +532,10 @@ function find_psi_2nd_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision
             # abs(psirange[end] - psirange[1]) / (abs(psirange[end] + psirange[1]) / 2.0) < precision
             if psi_sign > 0
                 #increasing psi
-                return (diverted = psi_separatrix, not_diverted = psi_spearatrix*(1+flux_surfaces_precision))
+                return (diverted = psi_separatrix, not_diverted = psi_separatrix*(1+flux_surfaces_precision))
             else
                 #decreasing psi
-                return (diverted = psi_separatrix, not_diverted = psi_spearatrix*(1-flux_surfaces_precision))
+                return (diverted = psi_separatrix, not_diverted = psi_separatrix*(1-flux_surfaces_precision))
             end
         end
     end

--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -525,8 +525,18 @@ function find_psi_2nd_separatrix(eqt::IMAS.equilibrium__time_slice{T}; precision
             continue
         end
         if (z[end] - ZA) * (z[1] - ZA) < 0
-            #if double null, all open surfaces in the SOL start and finish in opposite sides of the midplane
-            return psi_separatrix
+            # if perfect double null, all open surfaces in the SOL start and finish in opposite sides of the midplane
+            psi_axis = eqt.profiles_1d.psi[1] # psi value on axis
+            psi_sign = sign(psi_separatrix - psi_axis) # +1 for increasing psi / -1 for decreasing psi
+            # return psi_2ndsep = psi_lcfs, using same convergence criteria as in find_psi_boundary (~ line 436): 
+            # abs(psirange[end] - psirange[1]) / (abs(psirange[end] + psirange[1]) / 2.0) < precision
+            if psi_sign > 0
+                #increasing psi
+                return (diverted = psi_separatrix, not_diverted = psi_spearatrix*(1+flux_surfaces_precision))
+            else
+                #decreasing psi
+                return (diverted = psi_separatrix, not_diverted = psi_spearatrix*(1-flux_surfaces_precision))
+            end
         end
     end
 

--- a/src/physics/sol.jl
+++ b/src/physics/sol.jl
@@ -1108,13 +1108,13 @@ function find_strike_points(
                 else
                     continue
                 end
-                Rxx_, Zx_ = find_strike_points(pr, pz, strike_surfaces_r, strike_surfaces_z)
+                Rx_, Zx_ = find_strike_points(pr, pz, strike_surfaces_r, strike_surfaces_z)
                 # compute dxx
                 dx_, k1, _ = minimum_distance_polygons_vertices(pr, pz, bnd.r, bnd.z)
 
                 # We save 2 strike points per surface
                 # if there are more than 2 strike points per surface, filter shadowed strike-points
-                if length(Rxx_) > 2
+                if length(Rx_) > 2
                     # the surface identified by (pr,pz) itersects the wall more than twice,
                     # Retrieve only the segments of (pr,pz) inside the wall
                     ps = Tuple{Float64, Float64}[] 
@@ -1133,7 +1133,7 @@ function find_strike_points(
 
                     if L == 1
                         # only one segment inside wall: strike points found.
-                        Rxx_ = [p[1] for p in ps]
+                        Rx_ = [p[1] for p in ps]
                         Zx_  = [p[2] for p in ps]
                     else
                         # pick point on (pr,pz) closest to boundary (lcfs)
@@ -1146,21 +1146,21 @@ function find_strike_points(
                         # odd positions in ps are starting points of the segment, even position are the end
                         indx = argmin(dist) # index of closest point in ps to X
                         if iseven(indx)
-                            Rxx_ = [ps[indx-1][1], ps[indx][1]]
+                            Rx_ = [ps[indx-1][1], ps[indx][1]]
                             Zx_ = [ps[indx-1][2], ps[indx][2]]
                         else
-                            Rxx_ = [ps[indx][1], ps[indx+1][1]]
+                            Rx_ = [ps[indx][1], ps[indx+1][1]]
                             Zx_ = [ps[indx][2], ps[indx+1][2]]
                         end
                     end
                 end
 
-                # save strike-points in counter-clockwise order. Note: from here on, length(Rxx_) = 2
-                angle = mod.(atan.(Zx_ .- zaxis, Rxx_ .- raxis), 2 * π) # counter-clockwise angle form geom axis
+                # save strike-points in counter-clockwise order. Note: from here on, length(Rx_) = 2
+                angle = mod.(atan.(Zx_ .- zaxis, Rx_ .- raxis), 2 * π) # counter-clockwise angle form geom axis
 
-                append!(Rxx, Rxx_[sortperm(angle)])
+                append!(Rxx, Rx_[sortperm(angle)])
                 append!(Zxx, Zx_[sortperm(angle)])
-                append!(dxx, dx_ .* ones(length(Rxx_)))
+                append!(dxx, dx_ .* ones(length(Rx_)))
             end
         end
     end

--- a/src/physics/sol.jl
+++ b/src/physics/sol.jl
@@ -176,7 +176,7 @@ function sol(eqt::IMAS.equilibrium__time_slice, wall_r::AbstractVector{T}, wall_
     end
 
     # find psi at second magnetic separatrix
-    psi__2nd_separatix = find_psi_2nd_separatrix(eqt; type=:not_diverted) # find psi at 2nd magnetic separatrix
+    psi__2nd_separatix = find_psi_2nd_separatrix(eqt).not_diverted # find psi at 2nd magnetic separatrix
     psi_sign = sign(psi__boundary_level - psi__axis_level) # sign of the poloidal flux taking psi_axis = 0
     psi_max = find_psi_max(eqt)
 
@@ -345,7 +345,7 @@ function find_levels_from_P(
     end
 
     psi__boundary_level = find_psi_boundary(eqt, wall_r, wall_z; raise_error_on_not_open=true).first_open # psi at LCFS
-    psi_2ndseparatrix = find_psi_2nd_separatrix(eqt; type=:not_diverted) # psi of the second magnetic separatrix
+    psi_2ndseparatrix = find_psi_2nd_separatrix(eqt).not_diverted # psi of the second magnetic separatrix
     if psi_sign > 0
         r_separatrix_midplane = r_mid(psi__boundary_level)      # R OMP at separatrix
         r_2ndseparatrix_midplane = r_mid(psi_2ndseparatrix) # R coordinate at OMP of 2nd magnetic separatrix

--- a/src/physics/sol.jl
+++ b/src/physics/sol.jl
@@ -1178,7 +1178,7 @@ push!(document[Symbol("Physics sol")], :find_strike_points)
         in_place::Bool=true
     ) where {T1<:Real,T2<:Real,T3<:Real}
 
-Adds strike points location to equilibrium IDS and the tilt_angle_pol in the divertors IDS
+Adds strike points location to equilibrium IDS 
 """
 function find_strike_points!(
     eqt::IMAS.equilibrium__time_slice{T1},
@@ -1194,8 +1194,6 @@ function find_strike_points!(
     Rxx = Float64[]
     Zxx = Float64[]
     dxx = Float64[]
-
-    time = eqt.time
 
     for divertor in dv.divertor
         for target in divertor.target
@@ -1216,9 +1214,6 @@ function find_strike_points!(
             push!(Rxx, Rxx0[1])
             push!(Zxx, Zxx0[1])
             push!(dxx, dxx0[1])
-            if in_place
-                set_time_array(target.tilt_angle_pol, :data, time, θxx0[1])
-            end
         end
     end
 

--- a/src/physics/thermal_loads.jl
+++ b/src/physics/thermal_loads.jl
@@ -82,7 +82,9 @@ function particle_heat_flux(
 
     q_interp = interp1d(r, q, :cubic)
 
-    if eqt.boundary.x_point[1].z < ZA
+    # to determine if upper or lower single null, check if Z(strike_point) < Z(axis)
+    # SOL[:lfs][1] = LCFS
+    if SOL[:lfs][1].z[1]< ZA
         case = :lower
     else
         case = :upper
@@ -504,7 +506,9 @@ function mesher_heat_flux(dd::IMAS.dd;
     Zwall = Float64[]
     indexes = Int64[]
 
-    if eqt.boundary.x_point[1].z < Z0
+    # to determine if upper or lower single null, check if Z(strike_point) < Z(axis)
+    # SOL[:lfs][1] = LCFS
+    if SOL[:lfs][1].z[1]< Z0 
         case = :lower
     else
         case = :upper


### PR DESCRIPTION
Re-structure of IMAS.find_strike_points!. This is the current rationale:

The function returns 2 strike points for each (:any) surface with psi equal to that of the lcfs. In this way, one excludes the magnetically shadowed intersections. The strike points are picked only form the extrema of segments inside the wall. If multiple segments inside the wall exist for a surface, the segment closer to the LCFS is chosen.

find_strike_point do not compute anymore the poloidal angle (strike angle) between the lcfs and the divertor targets. This angle is used in ActorDivertors. However, I was happy to find that in that Actor, IMAS.sol() was already implemented for that purpose. So this functionality of find_strike_point was obsolete, and no changes seem to be required at the moment (i.e. fill dd up somewhere else).

I also implemented a minor improvement for the function intersection_split, where we add a middle point in the segment, if it is only made of the two crossing points with the wall. This was needed to avoid missing segments inside the wall (i.e. if a segment is made only of the two crossings, it is not considered inside the wall).

Note: in this, I merged also the branche for this open PR: https://github.com/ProjectTorreyPines/IMAS.jl/pull/242 