### PR TITLE
Fix bug in plot.jl: case when dd.build.layer is empty

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -916,8 +916,10 @@ end
     aspect_ratio := :equal
     grid --> :none
 
-    rmax = maximum(bd.layer[end].outline.r)
-    xlim --> [0, rmax]
+    if !isempty(bd.layer)
+        rmax = maximum(bd.layer[end].outline.r)
+        xlim --> [0, rmax]
+    end
 
     if dd !== nothing && equilibrium
         @series begin
@@ -962,7 +964,7 @@ end
     grid --> :none
 
     # cx
-    if cx
+    if cx && !isempty(layers)
         rmax = maximum(layers[end].outline.r)
 
         # everything after first vacuum in _out_


### PR DESCRIPTION
Do not plot cx if dd.build.layer is empty.

Error was thrown for
`dd = IMAS.dd()`
`ini, act = FUSE.case_parameters(:UNIT)`
`FUSE.init(dd, ini, act)`
`FUSE.digest(dd)`