### PR TITLE
ITER Nb3Sn thermal and JxB strain were overwritten 

### DIFF
--- a/src/physics/technology.jl
+++ b/src/physics/technology.jl
@@ -80,6 +80,9 @@ function coil_technology(coil_tech::Union{IMAS.build__pf_active__technology,IMAS
         coil_tech.fraction_void = 0.1
     end
 
+    coil_tech.thermal_strain = 0.0
+    coil_tech.JxB_strain = 0.0
+
     if technology == :nb3sn_iter
         if coil_type == :oh
             coil_tech.thermal_strain = -0.64
@@ -95,9 +98,6 @@ function coil_technology(coil_tech::Union{IMAS.build__pf_active__technology,IMAS
             coil_tech.fraction_steel = 0.46
         end
     end
-
-    coil_tech.thermal_strain = 0.0
-    coil_tech.JxB_strain = 0.0
 
     return coil_tech
 end


### PR DESCRIPTION
Minor bug where values of thermal strain and JxB strain induced on Nb3Sn for the ITER design were being overwritten with zeros, giving overly optimistic values of critical current density. 

Ideally I'd like to find where these strain numbers came from in the first place. I went back in the git blame and saw @orso82 originally added these numbers - any idea what source they came from? They're close but not identical to some thermal strain values found in this paper: https://www.researchgate.net/publication/223365515_Review_of_Nb3Sn_conductors_for_ITER

![Screenshot 2025-07-02 at 1 09 05 PM](https://github.com/user-attachments/assets/3ef2ff4d-dfae-4985-ad74-536ca5f73db0)

The JxB strains have been more challenging to track down... 

S/O @TimSlendebroek and @ggdose for helping uncover this 
