### PR TITLE
Use IMASdd setter functions instead of Val-dispatch

### DIFF
--- a/src/expressions/dynamic.jl
+++ b/src/expressions/dynamic.jl
@@ -1,11 +1,17 @@
 import IMASutils: trapz, cumtrapz
 
-function IMASdd.get_expressions(::Type{Val{:dynamic}})
-    return dynamic_expressions
-end
-
 const dynamic_expressions = Dict{String,Function}()
 dyexp = dynamic_expressions
+
+# Register the reference into IMASdd
+if isdefined(IMASdd, :set_dynamic_expressions)
+    IMASdd.set_dynamic_expressions(dynamic_expressions)
+else
+    # TODO: Remove.
+    function IMASdd.get_expressions(::Type{Val{:dynamic}})
+        return dynamic_expressions
+    end
+end
 
 #= =========== =#
 # core_profiles #

--- a/src/expressions/onetime.jl
+++ b/src/expressions/onetime.jl
@@ -1,11 +1,17 @@
 document[:Expressions] = Symbol[]
 
-function IMASdd.get_expressions(::Type{Val{:onetime}})
-    return onetime_expressions
-end
-
 const onetime_expressions = Dict{String,Function}()
 otexp = onetime_expressions
+
+# Register the reference into IMASdd
+if isdefined(IMASdd, :set_onetime_expressions)
+    IMASdd.set_onetime_expressions(onetime_expressions)
+else
+    # TODO: Remove.
+    function IMASdd.get_expressions(::Type{Val{:dynamic}})
+        return dynamic_expressions
+    end
+end
 
 # These expressions are frozen the first time they are accessed.
 # This is necessary to ensure that core_profiles, core_sources, and core_transport grids do not change after changing the equilibrium.


### PR DESCRIPTION
This patch make use of the new `set_(dynamic|onetime)_expressions`
functions in IMASdd to register the data structures. See
https://github.com/ProjectTorreyPines/IMASdd.jl/pull/77 for more
details.
