### PR TITLE
(refac): Accept abstract `IMAS.DD` in fusion power signatures

### DIFF
--- a/src/physics/nuclear.jl
+++ b/src/physics/nuclear.jl
@@ -510,8 +510,7 @@ end
 """
     fusion_power(dd::IMAS.DD; time0::Float64=dd.global_time, DD_fusion::Bool=false)
 
-Accepts any `IMAS.DD` subtype so satellite packages whose own top-level
-container (e.g. IFEdd's `dd_ife`) embeds `core_profiles` can call through.
+Calculates the total fusion power [W] at `time0` from `dd.core_profiles`.
 """
 function fusion_power(dd::IMAS.DD; time0::Float64=dd.global_time, DD_fusion::Bool=false)
     return fusion_power(dd.core_profiles.profiles_1d[time0]; DD_fusion)
@@ -556,8 +555,8 @@ end
 """
     fusion_neutron_power(dd::IMAS.DD)
 
-Accepts any `IMAS.DD` subtype so satellite packages whose own top-level
-container (e.g. IFEdd's `dd_ife`) embeds `core_profiles` can call through.
+Calculates the total fusion power in neutrons [W] from the current time
+slice of `dd.core_profiles`.
 """
 function fusion_neutron_power(dd::IMAS.DD)
     return fusion_neutron_power(dd.core_profiles.profiles_1d[])

--- a/src/physics/nuclear.jl
+++ b/src/physics/nuclear.jl
@@ -508,9 +508,12 @@ function fusion_power(cp1d::IMAS.core_profiles__profiles_1d{T}; DD_fusion::Bool=
 end
 
 """
-    fusion_power(dd::IMAS.dd; DD_fusion::Bool=false)
+    fusion_power(dd::IMAS.DD; time0::Float64=dd.global_time, DD_fusion::Bool=false)
+
+Accepts any `IMAS.DD` subtype so satellite packages whose own top-level
+container (e.g. IFEdd's `dd_ife`) embeds `core_profiles` can call through.
 """
-function fusion_power(dd::IMAS.dd; time0::Float64=dd.global_time, DD_fusion::Bool=false)
+function fusion_power(dd::IMAS.DD; time0::Float64=dd.global_time, DD_fusion::Bool=false)
     return fusion_power(dd.core_profiles.profiles_1d[time0]; DD_fusion)
 end
 
@@ -518,11 +521,11 @@ end
 push!(document[Symbol("Physics nuclear")], :fusion_power)
 
 """
-    fusion_energy(dd::IMAS.dd{T}; DD_fusion::Bool=false) where {T<:Real}
+    fusion_energy(dd::IMAS.DD{T}; DD_fusion::Bool=false) where {T<:Real}
 
 Fusion energy in [J]: fusion power integrated over simulation time
 """
-function fusion_energy(dd::IMAS.dd{T}; DD_fusion::Bool=false) where {T<:Real}
+function fusion_energy(dd::IMAS.DD{T}; DD_fusion::Bool=false) where {T<:Real}
     time = Float64[cp1d.time for cp1d in dd.core_profiles.profiles_1d]
     data = T[fusion_power(cp1d; DD_fusion) for cp1d in dd.core_profiles.profiles_1d]
     return trapz(time, data) / (time[end] - time[1])
@@ -551,9 +554,12 @@ function fusion_neutron_power(cp1d::IMAS.core_profiles__profiles_1d)
 end
 
 """
-    fusion_neutron_power(dd::IMAS.dd)
+    fusion_neutron_power(dd::IMAS.DD)
+
+Accepts any `IMAS.DD` subtype so satellite packages whose own top-level
+container (e.g. IFEdd's `dd_ife`) embeds `core_profiles` can call through.
 """
-function fusion_neutron_power(dd::IMAS.dd)
+function fusion_neutron_power(dd::IMAS.DD)
     return fusion_neutron_power(dd.core_profiles.profiles_1d[])
 end
 


### PR DESCRIPTION
## Summary

Relax three fusion-power physics functions to accept any `IMAS.DD` subtype, so packages built on top of IMAS (e.g. IFE-related workflows or other FUSE-based applications that define their own DD subtype) can call them on their own top-level container without re-implementing the body.

## Changes (1 file, 6 lines)

In `src/physics/nuclear.jl`, `dd::IMAS.dd` → `dd::IMAS.DD` for:

- `fusion_power(dd; …)`
- `fusion_energy(dd; …)`
- `fusion_neutron_power(dd)`

Each body only accesses `dd.core_profiles.profiles_1d[…]`, which is available on any DD subtype that embeds `core_profiles`.

## Compatibility

Pure widening. `IMAS.dd <: IMAS.DD`, so every existing call site dispatches to the same method as before. No behavioral change, no performance change (Julia still specializes on the concrete type at compile time).

## Scope

Minimally invasive on purpose: only these three functions are touched, and only because their bodies are already trivially generic over the container. In principle most `dd::IMAS.dd` annotations on functions that touch only shared IDS could receive the same treatment, but this PR keeps the change small and easy to verify — broader relaxation can follow in separate PRs as concrete need emerges.
