### PR TITLE
(refac): widen IMAS.dd to IMAS.DD

### DIFF
--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -8,7 +8,7 @@ document[Symbol("Benchmark")] = Symbol[]
 Struct for benchmarking time-dependent dd data structures
 """
 struct Benchmark{T}
-    dd::IMAS.dd{T}
+    dd::IMAS.DD{T}
     data::Dict{String,Vector{T}}
 end
 
@@ -16,11 +16,11 @@ end
 push!(document[Symbol("Benchmark")], :Benchmark)
 
 """
-    Benchmark(dd::IMAS.dd{T}) where {T<:Real}
+    Benchmark(dd::IMAS.DD{T}) where {T<:Real}
 
 Construct Benchmark from frozen dd, extracting all leaf data
 """
-function Benchmark(dd::IMAS.dd{T}) where {T<:Real}
+function Benchmark(dd::IMAS.DD{T}) where {T<:Real}
     @assert IMAS.isfrozen(dd)
 
     data = Dict{String,Vector{T}}()
@@ -50,11 +50,11 @@ function Benchmark(dd::IMAS.dd{T}) where {T<:Real}
 end
 
 """
-    benchmark(dd_ben::IMAS.dd{T}, times::AbstractVector{Float64}) where {T<:Real}
+    benchmark(dd_ben::IMAS.DD{T}, times::AbstractVector{Float64}) where {T<:Real}
 
 Evaluate self-consistency of a given IDS (flux-matching errors, etc.)
 """
-function benchmark(dd_ben::IMAS.dd{T}, times::AbstractVector{Float64}) where {T<:Real}
+function benchmark(dd_ben::IMAS.DD{T}, times::AbstractVector{Float64}) where {T<:Real}
     dd_cst = IMAS.dd(; frozen=true)
 
     for time0 in times
@@ -129,11 +129,11 @@ function benchmark(dd_ben::IMAS.dd{T}, times::AbstractVector{Float64}) where {T<
 end
 
 """
-    benchmark(dd_ben::IMAS.dd{T}, dd_ref::IMAS.dd{T}, times::AbstractVector{Float64}; self_benchmark::Bool=true) where {T<:Real}
+    benchmark(dd_ben::IMAS.DD{T}, dd_ref::IMAS.DD{T}, times::AbstractVector{Float64}; self_benchmark::Bool=true) where {T<:Real}
 
 Benchmark two dd structures at specified times
 """
-function benchmark(dd_ben::IMAS.dd{T}, dd_ref::IMAS.dd{T}, times::AbstractVector{Float64}; self_benchmark::Bool=true) where {T<:Real}
+function benchmark(dd_ben::IMAS.DD{T}, dd_ref::IMAS.DD{T}, times::AbstractVector{Float64}; self_benchmark::Bool=true) where {T<:Real}
     if self_benchmark
         dd_cst = benchmark(dd_ben, times).dd
     else

--- a/src/control/fxp.jl
+++ b/src/control/fxp.jl
@@ -14,7 +14,7 @@ mutable struct FxpDD
     client::Jedis.Client
 end
 
-function Base.deepcopy_internal(x::IMAS.dd{T}, dict::IdDict) where {T<:Real}
+function Base.deepcopy_internal(x::IMAS.DD{T}, dict::IdDict) where {T<:Real}
     if haskey(dict, x)
         return dict[x]
     end
@@ -43,7 +43,7 @@ function Base.deepcopy_internal(x::IMAS.dd{T}, dict::IdDict) where {T<:Real}
     return new_obj
 end
 
-function fxp_connect(dd::IMAS.dd; host::String="localhost", port::Int=55000, password::String="redispw")
+function fxp_connect(dd::IMAS.DD; host::String="localhost", port::Int=55000, password::String="redispw")
     aux = getfield(dd, :_aux)
     client = Jedis.Client(; host, port, password, keepalive_enable=true)
     identifier = string(objectid(dd))
@@ -62,7 +62,7 @@ function fxp_client(dd)
     end
 end
 
-function fxp_identifier(dd::IMAS.dd)
+function fxp_identifier(dd::IMAS.DD)
     aux = getfield(dd, :_aux)
     if :fxp ∈ keys(aux)
         return aux[:fxp].identifier
@@ -71,7 +71,7 @@ function fxp_identifier(dd::IMAS.dd)
     end
 end
 
-function fxp_has_service_provider(dd::IMAS.dd, service_name::String)
+function fxp_has_service_provider(dd::IMAS.DD, service_name::String)
     client = fxp_client(dd)
     if client !== nothing
         return FXP.has_service_provider(client, service_name)
@@ -80,12 +80,12 @@ function fxp_has_service_provider(dd::IMAS.dd, service_name::String)
     end
 end
 
-function fxp_negotiate_service(dd::IMAS.dd, service_name::String)
+function fxp_negotiate_service(dd::IMAS.DD, service_name::String)
     client = fxp_client(dd)
     return FXP.negotiate_service(client, fxp_identifier(dd), service_name)
 end
 
-function fxp_request_service(dd::IMAS.dd, service_name::String)
+function fxp_request_service(dd::IMAS.DD, service_name::String)
     if fxp_has_service_provider(dd, service_name)
         fxp_negotiate_service(dd, service_name)
         return true

--- a/src/experiments/fit.jl
+++ b/src/experiments/fit.jl
@@ -14,7 +14,7 @@ function (nnmi::NaturalNeighboursMeasurementInterpolator)(rho::AbstractVector{<:
 end
 
 """
-    fit2d(what::Val, dd::IMAS.dd{T}; transform::F=x -> x) where {T<:Real, F<:Function}
+    fit2d(what::Val, dd::IMAS.DD{T}; transform::F=x -> x) where {T<:Real, F<:Function}
 
 Create 2D interpolation of experimental data over time and radial coordinate.
 
@@ -24,7 +24,7 @@ Returns interpolation function for 2D data (rho, time) -> transformed_data
 
 NOTE: what is a Val{<:Symbol} that gets passed to the `getrawdata(what, dd)`
 """
-function fit2d(what::Val, dd::IMAS.dd{T}; transform::F=x -> x) where {T<:Real,F<:Function}
+function fit2d(what::Val, dd::IMAS.DD{T}; transform::F=x -> x) where {T<:Real,F<:Function}
     meas = getdata(what, dd)
     transformed_data = transform.(meas.data)::typeof(meas.data) # force type for empty arrays
     return fit2d(meas.time, meas.rho, transformed_data)

--- a/src/experiments/getdata.jl
+++ b/src/experiments/getdata.jl
@@ -1,7 +1,7 @@
 """
     getdata(
         what_val::Union{Val{:t_i},Val{:n_i_over_n_e},Val{:zeff},Val{:n_imp},Val{:ω_tor}},
-        dd::IMAS.dd{T},
+        dd::IMAS.DD{T},
         time0::Union{Nothing,Float64}=nothing,
         time_averaging::Float64=0.0
     ) where {T<:Real}
@@ -18,7 +18,7 @@ Data is always of type Measurements.Measurement{T}
 """
 function getdata(
     what_val::Union{Val{:t_i},Val{:n_i_over_n_e},Val{:zeff},Val{:n_imp},Val{:ω_tor}},
-    dd::IMAS.dd{T},
+    dd::IMAS.DD{T},
     time0::Union{Nothing,Float64}=nothing,
     time_averaging::Float64=0.0
 ) where {T<:Real}
@@ -124,7 +124,7 @@ function getdata(
 end
 
 """
-    getdata(what_val::Union{Val{:t_e},Val{:n_e}}, dd::IMAS.dd{T}, time0::Union{Nothing,Float64}=nothing, time_averaging::Float64=0.0) where {T<:Real}
+    getdata(what_val::Union{Val{:t_e},Val{:n_e}}, dd::IMAS.DD{T}, time0::Union{Nothing,Float64}=nothing, time_averaging::Float64=0.0) where {T<:Real}
 
 Extract Thomson scattering data for electron temperature or density.
 
@@ -136,7 +136,7 @@ Returns NamedTuple with (:time, :rho, :data, :weights)
 
 Data is always of type Measurements.Measurement{T}
 """
-function getdata(what_val::Union{Val{:t_e},Val{:n_e}}, dd::IMAS.dd{T}, time0::Union{Nothing,Float64}=nothing, time_averaging::Float64=0.0) where {T<:Real}
+function getdata(what_val::Union{Val{:t_e},Val{:n_e}}, dd::IMAS.DD{T}, time0::Union{Nothing,Float64}=nothing, time_averaging::Float64=0.0) where {T<:Real}
     what = typeof(what_val).parameters[1]
     ts = dd.thomson_scattering
 
@@ -197,7 +197,7 @@ function getdata(what_val::Union{Val{:t_e},Val{:n_e}}, dd::IMAS.dd{T}, time0::Un
 end
 
 """
-    getavg(what_val::Union{Val{:b_field_pol_probe},Val{:flux_loop}}, dd::IMAS.dd{T}, time0::Union{Nothing,Float64}=nothing, time_averaging::Float64=0.0) where {T<:Real}
+    getavg(what_val::Union{Val{:b_field_pol_probe},Val{:flux_loop}}, dd::IMAS.DD{T}, time0::Union{Nothing,Float64}=nothing, time_averaging::Float64=0.0) where {T<:Real}
 
 Averages magnetics data for b_field_pol_probe or flux_loop.
 
@@ -209,7 +209,7 @@ Returns NamedTuple with (:time, :data, :units)
 
 Data is always of type Measurements.Measurement{T}
 """
-function getavg(what_val::Union{Val{:b_field_pol_probe},Val{:flux_loop}}, dd::IMAS.dd{T}, time0::Float64=0.0, time_averaging::Float64=0.0) where {T<:Real}
+function getavg(what_val::Union{Val{:b_field_pol_probe},Val{:flux_loop}}, dd::IMAS.DD{T}, time0::Float64=0.0, time_averaging::Float64=0.0) where {T<:Real}
     what = typeof(what_val).parameters[1]
     ids = getproperty(dd.magnetics, what)
     if what == :b_field_pol_probe

--- a/src/extract/constraints.jl
+++ b/src/extract/constraints.jl
@@ -33,7 +33,7 @@ end
 @compat public ConstraintFunction
 push!(document[Symbol("Functions library")], :ConstraintFunction)
 
-function (cnst::ConstraintFunction)(dd::IMAS.dd)
+function (cnst::ConstraintFunction)(dd::IMAS.DD)
     return constraint_cost_transform(cnst.func(dd), cnst.operation, cnst.limit, cnst.tolerance)
 end
 

--- a/src/extract/extract.jl
+++ b/src/extract/extract.jl
@@ -35,7 +35,7 @@ function ExtractLibFunction(group::Symbol, name::Symbol, units::String, func::Fu
 end
 
 """
-    (xfun::ExtractFunction)(dd::IMAS.dd)
+    (xfun::ExtractFunction)(dd::IMAS.DD)
 
 Run the extract function and store its result in xfun.value
 
@@ -52,7 +52,7 @@ function (xfun::ExtractFunction)(dd::IMAS.DD)
 end
 
 """
-    extract(dd::IMAS.dd, library::Symbol=:extract)
+    extract(dd::IMAS.DD, library::Symbol=:extract)
 
 library can be one of:
 
@@ -83,7 +83,7 @@ function extract(dd::IMAS.DD, library::Symbol=:extract)
 end
 
 """
-    extract(dd::IMAS.dd, xtract::AbstractDict{Symbol,<:ExtractFunction})
+    extract(dd::IMAS.DD, xtract::AbstractDict{Symbol,<:ExtractFunction})
 
 Extract data from `dd`. Each of the `ExtractFunction` should accept `dd` as input, like this:
 
@@ -102,11 +102,11 @@ function extract(dd::IMAS.DD, xtract::AbstractDict{Symbol,<:ExtractFunction})
 end
 
 """
-    extract(dd::IMAS.dd, filename::AbstractString, args...; kw...)
+    extract(dd::IMAS.DD, filename::AbstractString, args...; kw...)
 
 Like `extract(dd)` but saves the data to HDF5 file
 """
-function extract(dd::IMAS.dd, filename::AbstractString, args...; kw...)
+function extract(dd::IMAS.DD, filename::AbstractString, args...; kw...)
     HDF5 = IMASdd.HDF5
     xtract = extract(dd, args...; kw...)
     HDF5.h5open(filename, "w") do fid
@@ -249,7 +249,7 @@ function print_tiled(io::IO, xtract::AbstractDict{Symbol,ExtractFunction}; termi
     end
 end
 
-function select_direct_captial_cost(dd::IMAS.dd, what::String)
+function select_direct_captial_cost(dd::IMAS.DD, what::String)
     for sys in dd.costing.cost_direct_capital.system
         idx = findfirst(x -> x.name == what, sys.subsystem)
         if !isnothing(idx)

--- a/src/extract/extract.jl
+++ b/src/extract/extract.jl
@@ -41,7 +41,7 @@ Run the extract function and store its result in xfun.value
 
 NOTE: NaN is assigned on error
 """
-function (xfun::ExtractFunction)(dd::IMAS.dd)
+function (xfun::ExtractFunction)(dd::IMAS.DD)
     try
         xfun.error = nothing
         return xfun.func(dd)
@@ -60,7 +60,7 @@ library can be one of:
   - `:moopt` => `ConstraintFunctionsLibrary` + `ObjectiveFunctionsLibrary`
   - `:all` => `ExtractFunctionsLibrary` + `ConstraintFunctionsLibrary` + `ObjectiveFunctionsLibrary`
 """
-function extract(dd::IMAS.dd, library::Symbol=:extract)
+function extract(dd::IMAS.DD, library::Symbol=:extract)
     if library == :extract
         return extract(dd, ExtractFunctionsLibrary)
     elseif library in (:moopt, :all)
@@ -92,7 +92,7 @@ Extract data from `dd`. Each of the `ExtractFunction` should accept `dd` as inpu
         :Te0 => ExtractFunction(:profiles, :Te0, "keV", dd -> dd.core_profiles.profiles_1d[].electrons.temperature[1] / 1E3)
     ]
 """
-function extract(dd::IMAS.dd, xtract::AbstractDict{Symbol,<:ExtractFunction})
+function extract(dd::IMAS.DD, xtract::AbstractDict{Symbol,<:ExtractFunction})
     xtract_out = OrderedCollections.OrderedDict{Symbol,ExtractFunction}()
     for xfun in values(xtract)
         xtract_out[xfun.name] = deepcopy(xfun)

--- a/src/extract/objectives.jl
+++ b/src/extract/objectives.jl
@@ -21,11 +21,11 @@ end
 push!(document[Symbol("Functions library")], :ObjectiveFunction)
 
 """
-    (objf::ObjectiveFunction)(dd::IMAS.dd)
+    (objf::ObjectiveFunction)(dd::IMAS.DD)
 
 From real domain to objective domain (Metaheuristics will always minimize)
 """
-function (objf::ObjectiveFunction)(dd::IMAS.dd)
+function (objf::ObjectiveFunction)(dd::IMAS.DD)
     if isinf(objf.target)
         if objf.target < 0
             return objf.func(dd)

--- a/src/get_from.jl
+++ b/src/get_from.jl
@@ -7,7 +7,7 @@ and is generally handy when coupling different codes/modules/actors.
 ===#
 
 # ip [A]
-function get_from(dd::IMAS.dd{T}, what::Val{:ip}, from_where::Symbol; time0::Float64=dd.global_time)::T where {T<:Real}
+function get_from(dd::IMAS.DD{T}, what::Val{:ip}, from_where::Symbol; time0::Float64=dd.global_time)::T where {T<:Real}
     if from_where == :equilibrium
         return Ip(dd.equilibrium.time_slice[time0])
     elseif from_where == :core_profiles
@@ -19,7 +19,7 @@ function get_from(dd::IMAS.dd{T}, what::Val{:ip}, from_where::Symbol; time0::Flo
 end
 
 # vacuum_r0_b0 [m], [T]
-function get_from(dd::IMAS.dd, what::Val{:vacuum_r0_b0}, from_where::Symbol; time0::Float64=dd.global_time)
+function get_from(dd::IMAS.DD, what::Val{:vacuum_r0_b0}, from_where::Symbol; time0::Float64=dd.global_time)
     if from_where == :equilibrium
         eqt = dd.equilibrium.time_slice[time0]
         return (r0=eqt.global_quantities.vacuum_toroidal_field.r0, b0=eqt.global_quantities.vacuum_toroidal_field.b0)
@@ -30,7 +30,7 @@ function get_from(dd::IMAS.dd, what::Val{:vacuum_r0_b0}, from_where::Symbol; tim
 end
 
 # vloop [V]
-function get_from(dd::IMAS.dd{T}, what::Val{:vloop}, from_where::Symbol; time0::Float64=dd.global_time)::T where {T<:Real}
+function get_from(dd::IMAS.DD{T}, what::Val{:vloop}, from_where::Symbol; time0::Float64=dd.global_time)::T where {T<:Real}
     if from_where == :equilibrium
         return vloop(dd.equilibrium; time0)
     elseif from_where == :core_profiles
@@ -44,7 +44,7 @@ function get_from(dd::IMAS.dd{T}, what::Val{:vloop}, from_where::Symbol; time0::
 end
 
 # beta_normal [-]
-function get_from(dd::IMAS.dd{T}, what::Val{:βn}, from_where::Symbol; time0::Float64=dd.global_time)::T where {T<:Real}
+function get_from(dd::IMAS.DD{T}, what::Val{:βn}, from_where::Symbol; time0::Float64=dd.global_time)::T where {T<:Real}
     if from_where == :equilibrium
         return dd.equilibrium.time_slice[time0].global_quantities.beta_normal
     elseif from_where == :core_profiles
@@ -54,7 +54,7 @@ function get_from(dd::IMAS.dd{T}, what::Val{:βn}, from_where::Symbol; time0::Fl
 end
 
 # ne_ped w/ pedestal fit [m^-3]
-function get_from(dd::IMAS.dd{T}, what::Val{:ne_ped}, from_where::Symbol, rho_ped::Nothing; time0::Float64=dd.global_time)::T where {T<:Real}
+function get_from(dd::IMAS.DD{T}, what::Val{:ne_ped}, from_where::Symbol, rho_ped::Nothing; time0::Float64=dd.global_time)::T where {T<:Real}
     if from_where == :core_profiles
         cp1d = dd.core_profiles.profiles_1d[time0]
         pedestal = pedestal_finder(cp1d.electrons.density_thermal, cp1d.grid.psi_norm)
@@ -67,7 +67,7 @@ function get_from(dd::IMAS.dd{T}, what::Val{:ne_ped}, from_where::Symbol, rho_pe
 end
 
 # ne_ped [m^-3]
-function get_from(dd::IMAS.dd{T}, what::Val{:ne_ped}, from_where::Symbol, rho_ped::Float64; time0::Float64=dd.global_time)::T where {T<:Real}
+function get_from(dd::IMAS.DD{T}, what::Val{:ne_ped}, from_where::Symbol, rho_ped::Float64; time0::Float64=dd.global_time)::T where {T<:Real}
     if from_where == :summary
         return get_time_array(dd.summary.local.pedestal.n_e, :value, time0)
     elseif from_where == :core_profiles
@@ -92,7 +92,7 @@ function get_from(dd::IMAS.dd{T}, what::Val{:ne_ped}, from_where::Symbol, rho_pe
 end
 
 # zeff_ped w/ pedestal fit [-]
-function get_from(dd::IMAS.dd{T}, what::Val{:zeff_ped}, from_where::Symbol, rho_ped::Nothing; time0::Float64=dd.global_time)::T where {T<:Real}
+function get_from(dd::IMAS.DD{T}, what::Val{:zeff_ped}, from_where::Symbol, rho_ped::Nothing; time0::Float64=dd.global_time)::T where {T<:Real}
     if from_where == :core_profiles
         cp1d = dd.core_profiles.profiles_1d[time0]
         pedestal = pedestal_finder(cp1d.electrons.density_thermal, cp1d.grid.psi_norm)
@@ -104,7 +104,7 @@ function get_from(dd::IMAS.dd{T}, what::Val{:zeff_ped}, from_where::Symbol, rho_
 end
 
 # zeff_ped [-]
-function get_from(dd::IMAS.dd{T}, what::Val{:zeff_ped}, from_where::Symbol, rho_ped::Float64; time0::Float64=dd.global_time)::T where {T<:Real}
+function get_from(dd::IMAS.DD{T}, what::Val{:zeff_ped}, from_where::Symbol, rho_ped::Float64; time0::Float64=dd.global_time)::T where {T<:Real}
     if from_where == :summary
         return get_time_array(dd.summary.local.pedestal.zeff, :value, time0)
     elseif from_where == :core_profiles
@@ -122,7 +122,7 @@ function get_from(dd::IMAS.dd{T}, what::Val{:zeff_ped}, from_where::Symbol, rho_
 end
 
 Base.Docs.@doc """
-    get_from(dd::IMAS.dd, what::Symbol, from_where::Symbol; time0::Float64=dd.global_time)
+    get_from(dd::IMAS.DD, what::Symbol, from_where::Symbol; time0::Float64=dd.global_time)
 
 IMAS stores the same physical quantities in different IDSs, and `get_from()` abstracts away the details
 of which IDS to access, depending on the requested quantity (`what`) and the specified source (`from_where`).

--- a/src/physics/build.jl
+++ b/src/physics/build.jl
@@ -207,7 +207,7 @@ function is_metallic_wall(bd::IMAS.build)
     return true
 end
 
-is_metallic_wall(dd::IMAS.dd) = is_metallic_wall(dd.build)
+is_metallic_wall(dd::IMAS.DD) = is_metallic_wall(dd.build)
 
 @compat public is_metallic_wall
 push!(document[Symbol("Physics build")], :is_metallic_wall)

--- a/src/physics/currents.jl
+++ b/src/physics/currents.jl
@@ -355,11 +355,11 @@ end
 push!(document[Symbol("Physics currents")], :Ip)
 
 """
-    plasma_lumped_resistance(dd::IMAS.dd)
+    plasma_lumped_resistance(dd::IMAS.DD)
 
 Returns equivalent plasma lumped resistance in ohms
 """
-function plasma_lumped_resistance(dd::IMAS.dd)
+function plasma_lumped_resistance(dd::IMAS.DD)
     cp1d = dd.core_profiles.profiles_1d[]
     eqt = dd.equilibrium.time_slice[]
     P_ohm = dd.core_sources.source[:ohmic].profiles_1d[].electrons.power_inside[end]

--- a/src/physics/fast.jl
+++ b/src/physics/fast.jl
@@ -371,7 +371,7 @@ function fast_particles_profiles!(cs::IMAS.core_sources, cp1d::IMAS.core_profile
     end
 end
 
-function fast_particles_profiles!(dd::IMAS.dd; verbose::Bool=false, modify_electron_density::Bool=false)
+function fast_particles_profiles!(dd::IMAS.DD; verbose::Bool=false, modify_electron_density::Bool=false)
     return fast_particles_profiles!(dd.core_sources, dd.core_profiles.profiles_1d[]; verbose, modify_electron_density)
 end
 

--- a/src/physics/fluxsurfaces.jl
+++ b/src/physics/fluxsurfaces.jl
@@ -2183,7 +2183,7 @@ push!(document[Symbol("Physics flux-surfaces")], :areal_elongation)
 
 
 """
-    rec_to_mxh_coeffs(dd::IMAS.dd)
+    rec_to_mxh_coeffs(dd::IMAS.DD)
 
 fits rectangular flux surface mesh in dd to MXH
 """

--- a/src/physics/neoclassical.jl
+++ b/src/physics/neoclassical.jl
@@ -68,13 +68,13 @@ end
 push!(document[Symbol("Physics neoclassical")], :collision_frequencies)
 
 """
-    Sauter_neo2021_bootstrap(dd::IMAS.dd; neo_2021::Bool, same_ne_ni::Bool)
+    Sauter_neo2021_bootstrap(dd::IMAS.DD; neo_2021::Bool, same_ne_ni::Bool)
 
 Calculates bootstrap current from the data dictionary. Both keyword arguments are required.
 
 See `Sauter_neo2021_bootstrap(eqt, cp1d; ...)` for details on the keyword arguments.
 """
-function Sauter_neo2021_bootstrap(dd::IMAS.dd; neo_2021::Bool, same_ne_ni::Bool)
+function Sauter_neo2021_bootstrap(dd::IMAS.DD; neo_2021::Bool, same_ne_ni::Bool)
     eqt = dd.equilibrium.time_slice[]
     cp1d = dd.core_profiles.profiles_1d[]
     return Sauter_neo2021_bootstrap(eqt, cp1d; neo_2021, same_ne_ni)
@@ -319,7 +319,7 @@ function Sauter_neo2021_bootstrap(
     return abs.(j_boot) .* sign(ip) ./ abs(B0)
 end
 
-function collisionless_bootstrap_coefficient(dd::IMAS.dd)
+function collisionless_bootstrap_coefficient(dd::IMAS.DD)
     eqt = dd.equilibrium.time_slice[]
     cp1d = dd.core_profiles.profiles_1d[]
     return collisionless_bootstrap_coefficient(eqt, cp1d)

--- a/src/physics/nuclear.jl
+++ b/src/physics/nuclear.jl
@@ -132,7 +132,7 @@ end
 push!(document[Symbol("Physics nuclear")], :D_T_to_He4_reactions)
 
 """
-    D_D_to_He3_reactions(dd::IMAS.dd)
+    D_D_to_He3_reactions(dd::IMAS.DD)
 
 Calculates the number of D-D thermal fusion reactions to He3 in [reactions/m³/s]
 """
@@ -162,7 +162,7 @@ end
 push!(document[Symbol("Physics nuclear")], :D_D_to_He3_reactions)
 
 """
-    D_D_to_T_reactions(dd::IMAS.dd)
+    D_D_to_T_reactions(dd::IMAS.DD)
 
 Calculates the number of D-D thermal fusion reactions to T in [reactions/m³/s]
 """
@@ -476,9 +476,9 @@ function fusion_plasma_power(cp1d::IMAS.core_profiles__profiles_1d)
 end
 
 """
-    fusion_plasma_power(dd::IMAS.dd)
+    fusion_plasma_power(dd::IMAS.DD)
 """
-function fusion_plasma_power(dd::IMAS.dd)
+function fusion_plasma_power(dd::IMAS.DD)
     return fusion_plasma_power(dd.core_profiles.profiles_1d[])
 end
 

--- a/src/physics/profiles.jl
+++ b/src/physics/profiles.jl
@@ -406,7 +406,7 @@ Evaluate thermal energy confinement time
 
 NOTE: This can go to infinity if there's more power coming out of the plasma than there is going in
 """
-function tau_e_thermal(dd::IMAS.dd; time0::Float64=dd.global_time, include_radiation::Bool=true, include_time_derivative::Bool=true)
+function tau_e_thermal(dd::IMAS.DD; time0::Float64=dd.global_time, include_radiation::Bool=true, include_time_derivative::Bool=true)
     cp1d = dd.core_profiles.profiles_1d[time0]
     tot_pow_in = total_power_inside(dd.core_sources, cp1d; time0, include_radiation, include_time_derivative)
     tot_pow_in = max(0.0, tot_pow_in)
@@ -418,7 +418,7 @@ end
 push!(document[Symbol("Physics profiles")], :tau_e_thermal)
 
 """
-    tau_e_h98(dd::IMAS.dd; time0::Float64=dd.global_time, include_radiation::Bool=true, include_time_derivative::Bool=true)
+    tau_e_h98(dd::IMAS.DD; time0::Float64=dd.global_time, include_radiation::Bool=true, include_time_derivative::Bool=true)
 
 H98y2 ITER elmy H-mode confinement time scaling
 
@@ -431,7 +431,7 @@ projected energy confinement time.
 
 See Table 5 in https://iopscience.iop.org/article/10.1088/0029-5515/39/12/302/pdf and https://iopscience.iop.org/article/10.1088/0029-5515/48/9/099801/pdf for additional correction with plasma_volume
 """
-function tau_e_h98(dd::IMAS.dd; time0::Float64=dd.global_time, include_radiation::Bool=true, include_time_derivative::Bool=true)
+function tau_e_h98(dd::IMAS.DD; time0::Float64=dd.global_time, include_radiation::Bool=true, include_time_derivative::Bool=true)
     eqt = dd.equilibrium.time_slice[time0]
     cp1d = dd.core_profiles.profiles_1d[time0]
     cs = dd.core_sources
@@ -467,13 +467,13 @@ end
 push!(document[Symbol("Physics profiles")], :tau_e_h98)
 
 """
-    tau_e_ds03(dd::IMAS.dd; time0::Float64=dd.global_time, include_radiation::Bool=true, include_time_derivative::Bool=true)
+    tau_e_ds03(dd::IMAS.DD; time0::Float64=dd.global_time, include_radiation::Bool=true, include_time_derivative::Bool=true)
 
 Petty's 2003 confinement time scaling
 
 NOTE: Petty uses elongation at the separatrix and makes no distinction between volume and line-average density
 """
-function tau_e_ds03(dd::IMAS.dd; time0::Float64=dd.global_time, include_radiation::Bool=true, include_time_derivative::Bool=true)
+function tau_e_ds03(dd::IMAS.DD; time0::Float64=dd.global_time, include_radiation::Bool=true, include_time_derivative::Bool=true)
     eqt = dd.equilibrium.time_slice[time0]
     cp1d = dd.core_profiles.profiles_1d[time0]
     cs = dd.core_sources
@@ -525,9 +525,9 @@ function greenwald_density(ip::T, minor_radius::T) where {T<:Real}
 end
 
 """
-    greenwald_density(dd::IMAS.dd)
+    greenwald_density(dd::IMAS.DD)
 """
-function greenwald_density(dd::IMAS.dd)
+function greenwald_density(dd::IMAS.DD)
     return greenwald_density(dd.equilibrium.time_slice[])
 end
 
@@ -555,9 +555,9 @@ function greenwald_fraction(eqt::IMAS.equilibrium__time_slice, cp1d::IMAS.core_p
 end
 
 """
-    greenwald_fraction(dd::IMAS.dd)
+    greenwald_fraction(dd::IMAS.DD)
 """
-function greenwald_fraction(dd::IMAS.dd)
+function greenwald_fraction(dd::IMAS.DD)
     return greenwald_fraction(dd.equilibrium.time_slice[], dd.core_profiles.profiles_1d[])
 end
 
@@ -591,9 +591,9 @@ function ne_line(eqt::IMAS.equilibrium__time_slice, cp1d::IMAS.core_profiles__pr
 end
 
 """
-    ne_line(dd::IMAS.dd; time0::Float64=dd.global_time)
+    ne_line(dd::IMAS.DD; time0::Float64=dd.global_time)
 """
-function ne_line(dd::IMAS.dd; time0::Float64=dd.global_time)
+function ne_line(dd::IMAS.DD; time0::Float64=dd.global_time)
     return ne_line(dd.equilibrium.time_slice[time0], dd.core_profiles.profiles_1d[time0])
 end
 
@@ -876,12 +876,12 @@ function scaling_L_to_H_power(cp1d::IMAS.core_profiles__profiles_1d, eqt::IMAS.e
 end
 
 """
-    scaling_L_to_H_power(dd::IMAS.dd; time0::Float64=dd.global_time)
+    scaling_L_to_H_power(dd::IMAS.DD; time0::Float64=dd.global_time)
 
 When `include_metallic_wall` is `nothing` (default) the wall type is auto-detected from
 `dd.build` via [`is_metallic_wall`](@ref); pass `true`/`false` to force it.
 """
-function scaling_L_to_H_power(dd::IMAS.dd; time0::Float64=dd.global_time,
+function scaling_L_to_H_power(dd::IMAS.DD; time0::Float64=dd.global_time,
     include_metallic_wall::Union{Nothing,Bool}=nothing, include_∇B_drift::Bool=true, include_isotope::Bool=true)
     metallic = include_metallic_wall === nothing ? is_metallic_wall(dd) : include_metallic_wall
     return scaling_L_to_H_power(dd.core_profiles.profiles_1d[time0], dd.equilibrium.time_slice[time0];
@@ -903,11 +903,11 @@ function L_H_threshold(cs::IMAS.core_sources, cp1d::IMAS.core_profiles__profiles
 end
 
 """
-    L_H_threshold(dd::IMAS.dd)
+    L_H_threshold(dd::IMAS.DD)
 
 The wall type (metallic vs. carbon) is auto-detected from `dd.build` via [`is_metallic_wall`](@ref).
 """
-function L_H_threshold(dd::IMAS.dd; time0::Float64=dd.global_time)
+function L_H_threshold(dd::IMAS.DD; time0::Float64=dd.global_time)
     return L_H_threshold(dd.core_sources, dd.core_profiles.profiles_1d[time0], dd.equilibrium.time_slice[time0];
         time0, include_metallic_wall=is_metallic_wall(dd))
 end
@@ -916,11 +916,11 @@ end
 push!(document[Symbol("Physics profiles")], :L_H_threshold)
 
 """
-    satisfies_h_mode_conditions(dd::IMAS.dd; threshold_multiplier::Float64=1.0)
+    satisfies_h_mode_conditions(dd::IMAS.DD; threshold_multiplier::Float64=1.0)
 
 Returns `true` if the plasma is diverted, has positive triangularity, and `Psol > Plh * threshold_multiplier`
 """
-function satisfies_h_mode_conditions(dd::IMAS.dd; threshold_multiplier::Float64=1.0)
+function satisfies_h_mode_conditions(dd::IMAS.DD; threshold_multiplier::Float64=1.0)
     Psol_gt_Plh = L_H_threshold(dd) > threshold_multiplier
     if Psol_gt_Plh
         return true
@@ -1026,9 +1026,9 @@ function is_quasi_neutral(cp1d::IMAS.core_profiles__profiles_1d; rtol::Float64=0
 end
 
 """
-    is_quasi_neutral(dd::IMAS.dd)
+    is_quasi_neutral(dd::IMAS.DD)
 """
-function is_quasi_neutral(dd::IMAS.dd; rtol::Float64=0.001)
+function is_quasi_neutral(dd::IMAS.DD; rtol::Float64=0.001)
     return is_quasi_neutral(dd.core_profiles.profiles_1d[]; rtol)
 end
 
@@ -1095,9 +1095,9 @@ function enforce_quasi_neutrality!(cp1d::IMAS.core_profiles__profiles_1d, specie
 end
 
 """
-    enforce_quasi_neutrality!(dd::IMAS.dd, species::Symbol)
+    enforce_quasi_neutrality!(dd::IMAS.DD, species::Symbol)
 """
-function enforce_quasi_neutrality!(dd::IMAS.dd, species::Symbol)
+function enforce_quasi_neutrality!(dd::IMAS.DD, species::Symbol)
     return enforce_quasi_neutrality!(dd.core_profiles.profiles_1d[], species)
 end
 
@@ -1460,7 +1460,7 @@ end
 push!(document[Symbol("Physics profiles")], :new_impurity_fraction!)
 
 """
-    new_impurity_radiation!(dd::IMAS.dd, impurity_name::Symbol, total_radiated_power::Real)
+    new_impurity_radiation!(dd::IMAS.DD, impurity_name::Symbol, total_radiated_power::Real)
 
 Add thermal impurity to core_profiles to match a total radiated power.
 
@@ -1468,7 +1468,7 @@ The new impurity will have the same density profile shape as the electron densit
 
 The main ion specie will be adjusted to have quasineutrality.
 """
-function new_impurity_radiation!(dd::IMAS.dd, impurity_name::Symbol, total_radiated_power::Real)
+function new_impurity_radiation!(dd::IMAS.DD, impurity_name::Symbol, total_radiated_power::Real)
     @assert total_radiated_power <= 0.0 "Radiated power must be <= 0.0"
     cp1d = dd.core_profiles.profiles_1d[]
 
@@ -1486,9 +1486,9 @@ function new_impurity_radiation!(dd::IMAS.dd, impurity_name::Symbol, total_radia
 end
 
 """
-    new_impurity_radiation!(dd::IMAS.dd, impurity_name::Symbol, time_total_radiated_power::AbstractVector{Float64}, value_total_radiated_power::AbstractVector{<:Real})
+    new_impurity_radiation!(dd::IMAS.DD, impurity_name::Symbol, time_total_radiated_power::AbstractVector{Float64}, value_total_radiated_power::AbstractVector{<:Real})
 """
-function new_impurity_radiation!(dd::IMAS.dd, impurity_name::Symbol, time_total_radiated_power::AbstractVector{Float64}, value_total_radiated_power::AbstractVector{<:Real})
+function new_impurity_radiation!(dd::IMAS.DD, impurity_name::Symbol, time_total_radiated_power::AbstractVector{Float64}, value_total_radiated_power::AbstractVector{<:Real})
     total_radiated_power_itp = IMAS.interp1d(time_total_radiated_power, value_total_radiated_power)
 
     global_time_bkp = dd.global_time

--- a/src/physics/radiation.jl
+++ b/src/physics/radiation.jl
@@ -24,11 +24,11 @@ end
 push!(document[Symbol("Physics radiation")], :radiation_losses)
 
 """
-    bremsstrahlung_source!(dd::IMAS.dd)
+    bremsstrahlung_source!(dd::IMAS.DD)
 
 Calculates approximate NRL Bremsstrahlung radiation source and modifies dd.core_sources
 """
-function bremsstrahlung_source!(dd::IMAS.dd)
+function bremsstrahlung_source!(dd::IMAS.DD)
     cp1d = dd.core_profiles.profiles_1d[]
     ne = cp1d.electrons.density_thermal
     Te = cp1d.electrons.temperature
@@ -76,11 +76,11 @@ end
 push!(document[Symbol("Physics radiation")], :rad_sync)
 
 """
-    synchrotron_source!(dd::IMAS.dd; wall_reflection_coefficient=0.0)
+    synchrotron_source!(dd::IMAS.DD; wall_reflection_coefficient=0.0)
 
 Calculates synchrotron radiation source and modifies dd.core_sources
 """
-function synchrotron_source!(dd::IMAS.dd; wall_reflection_coefficient=0.8)
+function synchrotron_source!(dd::IMAS.DD; wall_reflection_coefficient=0.8)
     cp1d = dd.core_profiles.profiles_1d[]
     ne = cp1d.electrons.density_thermal
     Te = cp1d.electrons.temperature
@@ -104,11 +104,11 @@ end
 push!(document[Symbol("Physics radiation")], :synchrotron_source!)
 
 """
-    line_radiation_source!(dd::IMAS.dd)
+    line_radiation_source!(dd::IMAS.DD)
 
 Calculates line radiation sources and modifies dd.core_sources
 """
-function line_radiation_source!(dd::IMAS.dd)
+function line_radiation_source!(dd::IMAS.DD)
     cp1d = dd.core_profiles.profiles_1d[]
     ne = cp1d.electrons.density_thermal
     Te = cp1d.electrons.temperature

--- a/src/physics/sol.jl
+++ b/src/physics/sol.jl
@@ -317,9 +317,9 @@ function sol(eqt::IMAS.equilibrium__time_slice, wall::IMAS.wall; levels::Union{I
 end
 
 """
-    sol(dd::IMAS.dd; levels::Union{Int,AbstractVector}=20, use_wall::Bool=true)
+    sol(dd::IMAS.DD; levels::Union{Int,AbstractVector}=20, use_wall::Bool=true)
 """
-function sol(dd::IMAS.dd; levels::Union{Int,AbstractVector}=20, use_wall::Bool=!isempty(first_wall(dd.wall).r))
+function sol(dd::IMAS.DD; levels::Union{Int,AbstractVector}=20, use_wall::Bool=!isempty(first_wall(dd.wall).r))
     return sol(dd.equilibrium.time_slice[], dd.wall; levels, use_wall)
 end
 
@@ -552,9 +552,9 @@ function find_levels_from_P(
 end
 
 """
-    find_levels_from_P(dd::IMAS.dd, r::Vector{<:Real}, q::Vector{<:Real}, levels::Int)
+    find_levels_from_P(dd::IMAS.DD, r::Vector{<:Real}, q::Vector{<:Real}, levels::Int)
 """
-function find_levels_from_P(dd::IMAS.dd, r::Vector{<:Real}, q::Vector{<:Real}, levels::Int)
+function find_levels_from_P(dd::IMAS.DD, r::Vector{<:Real}, q::Vector{<:Real}, levels::Int)
     _, _, PSI_interpolant = ψ_interpolant(dd.equilibrium.time_slice[].profiles_2d)
     return find_levels_from_P(dd.equilibrium.time_slice[], dd.wall, PSI_interpolant, q, r, levels)
 end
@@ -607,9 +607,9 @@ function find_levels_from_wall(eqt::IMAS.equilibrium__time_slice, wall::IMAS.wal
 end
 
 """
-    find_levels_from_wall(dd::IMAS.dd)
+    find_levels_from_wall(dd::IMAS.DD)
 """
-function find_levels_from_wall(dd::IMAS.dd)
+function find_levels_from_wall(dd::IMAS.DD)
     _, _, PSI_interpolant = ψ_interpolant(dd.equilibrium.time_slice[].profiles_2d)
     return find_levels_from_wall(dd.equilibrium.time_slice[], dd.wall, PSI_interpolant)
 end
@@ -874,9 +874,9 @@ function power_sol(core_sources::IMAS.core_sources, cp1d::IMAS.core_profiles__pr
 end
 
 """
-    power_sol(dd::IMAS.dd; time0::Float64=dd.global_time)
+    power_sol(dd::IMAS.DD; time0::Float64=dd.global_time)
 """
-function power_sol(dd::IMAS.dd; time0::Float64=dd.global_time)
+function power_sol(dd::IMAS.DD; time0::Float64=dd.global_time)
     return power_sol(dd.core_sources, dd.core_profiles.profiles_1d[time0]; time0)
 end
 
@@ -906,9 +906,9 @@ function widthSOL_loarte(eqt::IMAS.equilibrium__time_slice, cp1d::IMAS.core_prof
 end
 
 """
-    widthSOL_loarte(dd::IMAS.dd)
+    widthSOL_loarte(dd::IMAS.DD)
 """
-function widthSOL_loarte(dd::IMAS.dd)
+function widthSOL_loarte(dd::IMAS.DD)
     return widthSOL_loarte(dd.equilibrium.time_slice[], dd.core_profiles.profiles_1d[], dd.core_sources)
 end
 
@@ -957,9 +957,9 @@ function widthSOL_sieglin(eqt::IMAS.equilibrium__time_slice, cp1d::IMAS.core_pro
 end
 
 """
-    widthSOL_sieglin(dd::IMAS.dd)
+    widthSOL_sieglin(dd::IMAS.DD)
 """
-function widthSOL_sieglin(dd::IMAS.dd)
+function widthSOL_sieglin(dd::IMAS.DD)
     return widthSOL_sieglin(dd.equilibrium.time_slice[], dd.core_profiles.profiles_1d[], dd.core_sources)
 end
 
@@ -999,9 +999,9 @@ function widthSOL_eich(eqt::IMAS.equilibrium__time_slice, cp1d::IMAS.core_profil
 end
 
 """
-    widthSOL_eich(dd::IMAS.dd)
+    widthSOL_eich(dd::IMAS.DD)
 """
-function widthSOL_eich(dd::IMAS.dd)
+function widthSOL_eich(dd::IMAS.DD)
     return widthSOL_eich(dd.equilibrium.time_slice[], dd.core_profiles.profiles_1d[], dd.core_sources)
 end
 
@@ -1022,9 +1022,9 @@ function q_pol_omp_eich(eqt::IMAS.equilibrium__time_slice, cp1d::IMAS.core_profi
 end
 
 """
-    q_pol_omp_eich(dd::IMAS.dd)
+    q_pol_omp_eich(dd::IMAS.DD)
 """
-function q_pol_omp_eich(dd::IMAS.dd)
+function q_pol_omp_eich(dd::IMAS.DD)
     return q_pol_omp_eich(dd.equilibrium.time_slice[], dd.core_profiles.profiles_1d[], dd.core_sources)
 end
 
@@ -1045,9 +1045,9 @@ function q_par_omp_eich(eqt::IMAS.equilibrium__time_slice, cp1d::IMAS.core_profi
 end
 
 """
-    q_par_omp_eich(dd::IMAS.dd)
+    q_par_omp_eich(dd::IMAS.DD)
 """
-function q_par_omp_eich(dd::IMAS.dd)
+function q_par_omp_eich(dd::IMAS.DD)
     return q_par_omp_eich(dd.equilibrium.time_slice[], dd.core_profiles.profiles_1d[], dd.core_sources)
 end
 
@@ -1075,9 +1075,9 @@ function zohm_divertor_figure_of_merit(core_sources::IMAS.core_sources, cp1d::IM
 end
 
 """
-    zohm_divertor_figure_of_merit(dd::IMAS.dd)
+    zohm_divertor_figure_of_merit(dd::IMAS.DD)
 """
-function zohm_divertor_figure_of_merit(dd::IMAS.dd)
+function zohm_divertor_figure_of_merit(dd::IMAS.DD)
     return zohm_divertor_figure_of_merit(dd.core_sources, dd.core_profiles.profiles_1d[], dd.equilibrium.time_slice[])
 end
 

--- a/src/physics/sources.jl
+++ b/src/physics/sources.jl
@@ -31,9 +31,9 @@ function fusion_source!(cs::IMAS.core_sources, cp::IMAS.core_profiles; DD_fusion
 end
 
 """
-    fusion_source!(dd::IMAS.dd; DD_fusion::Bool=false)
+    fusion_source!(dd::IMAS.DD; DD_fusion::Bool=false)
 """
-function fusion_source!(dd::IMAS.dd; DD_fusion::Bool=false)
+function fusion_source!(dd::IMAS.DD; DD_fusion::Bool=false)
     return fusion_source!(dd.core_sources, dd.core_profiles; DD_fusion)
 end
 
@@ -41,11 +41,11 @@ end
 push!(document[Symbol("Physics sources")], :fusion_source!)
 
 """
-    collisional_exchange_source!(dd::IMAS.dd)
+    collisional_exchange_source!(dd::IMAS.DD)
 
 Calculates collisional exchange source and adds it to `dd.core_sources`
 """
-function collisional_exchange_source!(dd::IMAS.dd)
+function collisional_exchange_source!(dd::IMAS.DD)
     cp1d = dd.core_profiles.profiles_1d[]
     ne = cp1d.electrons.density_thermal
     Te = cp1d.electrons.temperature
@@ -65,11 +65,11 @@ end
 push!(document[Symbol("Physics sources")], :collisional_exchange_source!)
 
 """
-    ohmic_source!(dd::IMAS.dd)
+    ohmic_source!(dd::IMAS.DD)
 
 Calculates the ohmic source from data in `dd.core_profiles` and adds it to `dd.core_sources`
 """
-function ohmic_source!(dd::IMAS.dd)
+function ohmic_source!(dd::IMAS.DD)
     cp1d = dd.core_profiles.profiles_1d[]
     j_ohmic = getproperty(cp1d, :j_ohmic, missing)
     if !ismissing(j_ohmic)
@@ -94,12 +94,12 @@ end
 push!(document[Symbol("Physics sources")], :ohmic_source!)
 
 """
-    bootstrap_source!(dd::IMAS.dd)
+    bootstrap_source!(dd::IMAS.DD)
 
 Calculates the bootsrap current from profiles in `dd.core_profiles`
 and adds it both as source in `dd.core_sources` and `cp1d.j_bootstrap`
 """
-function bootstrap_source!(dd::IMAS.dd)
+function bootstrap_source!(dd::IMAS.DD)
     eqt = dd.equilibrium.time_slice[]
     cp1d = dd.core_profiles.profiles_1d[]
     j_bootstrap = Sauter_neo2021_bootstrap(eqt, cp1d)
@@ -114,7 +114,7 @@ end
 push!(document[Symbol("Physics sources")], :bootstrap_source!)
 
 """
-    radiation_source!(dd::IMAS.dd)
+    radiation_source!(dd::IMAS.DD)
 
 Calculates the total radiation by calling:
 
@@ -124,7 +124,7 @@ Calculates the total radiation by calling:
 
 NOTE: if found, it removes total :radiation source to avoid double counting radiation
 """
-function radiation_source!(dd::IMAS.dd)
+function radiation_source!(dd::IMAS.DD)
     # if we find a total radiation source, let's remove it,
     # since here we calculate the individual contributions
     # and we don't want to double count
@@ -143,7 +143,7 @@ end
 push!(document[Symbol("Physics sources")], :radiation_source!)
 
 """
-    intrinsic_sources!(dd::IMAS.dd; bootstrap::Bool=true, DD_fusion::Bool=false, fast_ion_densities::Bool=true)
+    intrinsic_sources!(dd::IMAS.DD; bootstrap::Bool=true, DD_fusion::Bool=false, fast_ion_densities::Bool=true)
 
 Calculates intrinsic sources and sinks, and adds them to `dd.core_sources`
 
@@ -152,7 +152,7 @@ Calculates intrinsic sources and sinks, and adds them to `dd.core_sources`
   - `fast_ion_densities`: Update fast ion density profiles after fusion source calculation
   - `modify_electron_density`: When updating fast ion densities, adjust the electron density to satisfy quasi-neutrality instead of subtracting the fast density from the thermal ion density
 """
-function intrinsic_sources!(dd::IMAS.dd; bootstrap::Bool=true, DD_fusion::Bool=false, fast_ion_densities::Bool=true, modify_electron_density::Bool=false)
+function intrinsic_sources!(dd::IMAS.DD; bootstrap::Bool=true, DD_fusion::Bool=false, fast_ion_densities::Bool=true, modify_electron_density::Bool=false)
 
     collisional_exchange_source!(dd) # electron and ion energy
 
@@ -173,13 +173,13 @@ end
 push!(document[Symbol("Physics sources")], :intrinsic_sources!)
 
 """
-    time_derivative_source!(dd::IMAS.dd, cp1d_old::IMAS.core_profiles__profiles_1d, Δt::Float64; zero_out::Bool)
+    time_derivative_source!(dd::IMAS.DD, cp1d_old::IMAS.core_profiles__profiles_1d, Δt::Float64; zero_out::Bool)
 
 Calculates time dependent sources and sinks, and adds them to `dd.core_sources`
 
 These are the ∂/∂t term in the transport equations
 """
-function time_derivative_source!(dd::IMAS.dd, cp1d_old::IMAS.core_profiles__profiles_1d, Δt::Float64; name::String="∂/∂t")
+function time_derivative_source!(dd::IMAS.DD, cp1d_old::IMAS.core_profiles__profiles_1d, Δt::Float64; name::String="∂/∂t")
     cp1d = dd.core_profiles.profiles_1d[]
     eqt1d = dd.equilibrium.time_slice[].profiles_1d
     R_flux_avg = interp1d(eqt1d.rho_tor_norm, eqt1d.gm8).(cp1d.grid.rho_tor_norm)
@@ -225,9 +225,9 @@ function time_derivative_source!(dd::IMAS.dd, cp1d_old::IMAS.core_profiles__prof
 end
 
 """
-    time_derivative_source!(dd::IMAS.dd; zero_out::Bool=false)
+    time_derivative_source!(dd::IMAS.DD; zero_out::Bool=false)
 """
-function time_derivative_source!(dd::IMAS.dd; name::String="∂/∂t", zero_out::Bool=false)
+function time_derivative_source!(dd::IMAS.DD; name::String="∂/∂t", zero_out::Bool=false)
     if zero_out
         time_derivative_source!(dd, dd.core_profiles.profiles_1d[], 0.0; name)
     else
@@ -534,9 +534,9 @@ function total_sources!(
 end
 
 """
-    total_sources(dd::IMAS.dd; time0::Float64=dd.global_time, kw...)
+    total_sources(dd::IMAS.DD; time0::Float64=dd.global_time, kw...)
 """
-function total_sources(dd::IMAS.dd; time0::Float64=dd.global_time, kw...)
+function total_sources(dd::IMAS.DD; time0::Float64=dd.global_time, kw...)
     return total_sources(dd.core_sources, dd.core_profiles.profiles_1d[time0]; time0, kw...)
 end
 
@@ -555,9 +555,9 @@ function total_radiation_sources(
 end
 
 """
-    total_radiation_sources(dd::IMAS.dd; time0::Float64=dd.global_time, kw...)
+    total_radiation_sources(dd::IMAS.DD; time0::Float64=dd.global_time, kw...)
 """
-function total_radiation_sources(dd::IMAS.dd; time0::Float64=dd.global_time, kw...)
+function total_radiation_sources(dd::IMAS.DD; time0::Float64=dd.global_time, kw...)
     return total_radiation_sources(dd.core_sources, dd.core_profiles.profiles_1d[time0]; time0, kw...)
 end
 
@@ -566,7 +566,7 @@ push!(document[Symbol("Physics sources")], :total_radiation_sources)
 
 
 """
-    sawteeth_source!(dd::IMAS.dd; qmin_desired::Union{Float64, Nothing}=nothing, flat_factor::Real=0.5)
+    sawteeth_source!(dd::IMAS.DD; qmin_desired::Union{Float64, Nothing}=nothing, flat_factor::Real=0.5)
 
 Model sawteeth by flattening all sources where abs(q) drops below qmin_desired.
 
@@ -574,7 +574,7 @@ Model sawteeth by flattening all sources where abs(q) drops below qmin_desired.
     `dd.sawteeth.diagnostics.rho_tor_norm_inversion` if available, otherwise falls back to `1.0`
   - `flat_factor`: Relaxation factor for flattening, from 0.0 (no change) to 1.0 (full flattening)
 """
-function sawteeth_source!(dd::IMAS.dd; qmin_desired::Union{Float64, Nothing}=nothing, flat_factor::Real=0.5)
+function sawteeth_source!(dd::IMAS.DD; qmin_desired::Union{Float64, Nothing}=nothing, flat_factor::Real=0.5)
 
     if qmin_desired === nothing
         if !ismissing(dd.sawteeth.diagnostics, :rho_tor_norm_inversion)
@@ -593,25 +593,25 @@ function sawteeth_source!(dd::IMAS.dd; qmin_desired::Union{Float64, Nothing}=not
     end
 end
 
-function sawteeth_source!(dd::IMAS.dd{T}, ::Nothing; flat_factor::Real=0.5) where {T<:Real}
+function sawteeth_source!(dd::IMAS.DD{T}, ::Nothing; flat_factor::Real=0.5) where {T<:Real}
     # no inversion radius, so call with rho0 = 0.0
     return sawteeth_source!(dd, 0.0; flat_factor)
 end
 
-function sawteeth_source!(dd::IMAS.dd{T}, i_qdes::Int; flat_factor::Real=0.5) where {T<:Real}
+function sawteeth_source!(dd::IMAS.DD{T}, i_qdes::Int; flat_factor::Real=0.5) where {T<:Real}
     cp1d = dd.core_profiles.profiles_1d[]
     return sawteeth_source!(dd, cp1d.grid.rho_tor_norm[i_qdes]; flat_factor)
 end
 
 """
-    sawteeth_source!(dd::IMAS.dd{T}, rho0::T; flat_factor::Real=0.5) where {T<:Real}
+    sawteeth_source!(dd::IMAS.DD{T}, rho0::T; flat_factor::Real=0.5) where {T<:Real}
 
 Model sawteeth by flattening all sources within the inversion radius rho0
 
   - `rho0`: Normalized toroidal flux coordinate of the inversion radius
   - `flat_factor`: Relaxation factor for flattening (0 = no change, 1 = full flattening)
 """
-function sawteeth_source!(dd::IMAS.dd{T}, rho0::T; flat_factor::Real=0.5) where {T<:Real}
+function sawteeth_source!(dd::IMAS.DD{T}, rho0::T; flat_factor::Real=0.5) where {T<:Real}
     @assert rho0 <= 1.0
     cp1d = dd.core_profiles.profiles_1d[]
 

--- a/src/physics/technology.jl
+++ b/src/physics/technology.jl
@@ -19,11 +19,11 @@ const pure_copper = MaterialProperties(;
 )
 
 """
-    mechanical_technology(dd::IMAS.dd, what::Symbol)
+    mechanical_technology(dd::IMAS.DD, what::Symbol)
 
 Set `yield_strength`, `poisson_ratio`, and `young_modulus` properties for `:pl`, `:oh` and `:tf`
 """
-function mechanical_technology(dd::IMAS.dd, what::Symbol)
+function mechanical_technology(dd::IMAS.DD, what::Symbol)
     @assert what in (:pl, :oh, :tf)
     if what != :pl && getproperty(dd.build, what).technology.material == "copper"
         material = pure_copper

--- a/src/physics/thermal_loads.jl
+++ b/src/physics/thermal_loads.jl
@@ -149,7 +149,7 @@ function core_radiation_heat_flux(
 end
 
 """
-    mesher_heat_flux(dd::IMAS.dd;
+    mesher_heat_flux(dd::IMAS.DD;
         r::AbstractVector{T}=Float64[],
         q::AbstractVector{T}=Float64[],
         merge_wall::Bool = true,
@@ -163,7 +163,7 @@ s                     curvilinear abscissa computed from (Rwall, Zwall), clockwi
 SOL                   list of OpenFieldLines used to compute (Rwall, Zwall)
 (r,q)                 Hypothesis of power density decay at omp for definition of SOL
 """
-function mesher_heat_flux(dd::IMAS.dd;
+function mesher_heat_flux(dd::IMAS.DD;
     r::AbstractVector{T}=Float64[],
     q::AbstractVector{T}=Float64[],
     merge_wall::Bool=true,

--- a/src/physics/transport.jl
+++ b/src/physics/transport.jl
@@ -216,9 +216,9 @@ function total_fluxes!(
 end
 
 """
-    total_fluxes(dd::IMAS.dd, rho_total_fluxes::AbstractVector{<:Real}=dd.core_profiles.profiles_1d[].grid.rho_tor_norm; time0::Float64=dd.global_time)
+    total_fluxes(dd::IMAS.DD, rho_total_fluxes::AbstractVector{<:Real}=dd.core_profiles.profiles_1d[].grid.rho_tor_norm; time0::Float64=dd.global_time)
 """
-function total_fluxes(dd::IMAS.dd, rho_total_fluxes::AbstractVector{<:Real}=dd.core_profiles.profiles_1d[].grid.rho_tor_norm; time0::Float64=dd.global_time)
+function total_fluxes(dd::IMAS.DD, rho_total_fluxes::AbstractVector{<:Real}=dd.core_profiles.profiles_1d[].grid.rho_tor_norm; time0::Float64=dd.global_time)
     return total_fluxes(dd.core_transport, dd.core_profiles.profiles_1d[], rho_total_fluxes; time0)
 end
 
@@ -228,7 +228,7 @@ end
 
 Compute transport particle, heat, and rotation diffusivities from desired profiles.
 """
-function calculate_diffusivities(dd::IMAS.dd{T}; ne::Vector{T}=T[], Te::Vector{T}=T[], Ti::Vector{T}=T[], ω::Vector{T}=T[]) where {T<:Real}
+function calculate_diffusivities(dd::IMAS.DD{T}; ne::Vector{T}=T[], Te::Vector{T}=T[], Ti::Vector{T}=T[], ω::Vector{T}=T[]) where {T<:Real}
 
     cs1d = IMAS.total_sources(dd)
     cp1d = dd.core_profiles.profiles_1d[]

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -4140,7 +4140,7 @@ end
     end
 end
 
-@recipe function plot_field_1d_manyDDs(ids::IDS, field::Symbol, DDs::AbstractVector{<:IMAS.dd})
+@recipe function plot_field_1d_manyDDs(ids::IDS, field::Symbol, DDs::AbstractVector{<:IMAS.DD})
     @series begin
         [IMAS.goto(dd, IMAS.location(ids)) for dd in DDs], field
     end


### PR DESCRIPTION
## Summary

Widen the concrete type signature of `IMAS.dd` in function arguments to the abstract type of `IMAS.DD`.

This is a harmless, preemptive refactoring in preparation for future use of different concrete subtypes of IMAS.DD (e.g., IFEdd, currently under development).